### PR TITLE
adding local packaging and pipeline script example

### DIFF
--- a/pipelines/acs/README.md
+++ b/pipelines/acs/README.md
@@ -1,0 +1,2 @@
+# ACS5 pipeline for Population Factfinder
+## Instructions:

--- a/pipelines/acs/demographic.py
+++ b/pipelines/acs/demographic.py
@@ -1,0 +1,20 @@
+from factfinder.main import Pff
+from factfinder.median import get_median, get_median_moe
+import os
+import pandas as pd
+import itertools
+
+pff = Pff(
+    api_key=os.environ['API_KEY'], 
+    year = 2018
+)
+
+geography = ['city', 'tract', 'NTA', 'cd']
+variables = [i['pff_variable'] for i in pff.metadata if i['domain'] == 'demographic'][0:5]
+dfs = []
+for var, geo in itertools.product(variables, geography):
+    try:
+        dfs.append(pff.calculate(var, geo))
+    except:
+        print(var, geo)
+df = pd.concat(dfs)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="pff-factfinder",
+    version="0.0.0",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/NYCPlanning/db-factfinder",
+    packages=setuptools.find_packages(),
+    python_requires='>=3.6',
+    install_requires=[
+        "pandas", 
+        "census", 
+        "cached-property"
+    ]
+)


### PR DESCRIPTION
- adding a folder `pipelines`, while it makes sense to publish factfinder as a package and to be used by community profiles, it still makes sense to store pipelines for acs/decennial in this current repo
- the current set up is similar to rdptools, we have a python package in a folder and pipelines in another folder. also `pipelines` = `recipes` in this case