### PR TITLE
Set p to 100, z to null for all base var

### DIFF
--- a/factfinder/main.py
+++ b/factfinder/main.py
@@ -176,14 +176,12 @@ class Pff:
         ] = 0
 
         df.loc[
-            df.geotype.isin(["borough", "city"])
-            & df.pff_variable.isin(self.base_variables),
+            df.pff_variable.isin(self.base_variables),
             "p",
         ] = 100
 
         df.loc[
-            df.geotype.isin(["borough", "city"])
-            & df.pff_variable.isin(self.base_variables),
+            df.pff_variable.isin(self.base_variables),
             "z",
         ] = np.nan
 


### PR DESCRIPTION
#41 

The proportion/proportion MOE should be 100/null for all base vars, regardless of geography.