### PR TITLE
Add lgoenlep1 for community profiles

### DIFF
--- a/factfinder/data/metadata.json
+++ b/factfinder/data/metadata.json
@@ -1,5 +1,36 @@
 [
     {
+        "pff_variable":"lgoenlep1",
+        "base_variable":"lgbase",
+        "census_variable": [
+            "C16001_005",
+            "C16001_008",
+            "C16001_011",
+            "C16001_014",
+            "C16001_017",
+            "C16001_020",
+            "C16001_023",
+            "C16001_026",
+            "C16001_029",
+            "C16001_032",
+            "C16001_035",
+            "C16001_038"
+        ],
+        "domain": "community_profiles",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable":"lgbase",
+        "base_variable":"lgbase",
+        "census_variable": [
+            "C16001_001"
+        ],
+        "domain": "community_profiles",
+        "rounding": 0,
+        "source": ""
+    },
+    {
         "pff_variable":"ownerocc",
         "base_variable":"occbaseunits",
         "census_variable": [


### PR DESCRIPTION
#43 

Future language data for PFF will come from the collapsed 5-year table C16001. This table is similar to the previous source, but collapsed languages into larger categories. Population has yet to scope out the variables they want for each language category. Because the variable `lgoenlep1` is the sum of low-english proficiency across all non-English languages, we can create this variable for Community Profiles prior to mapping out all language variables for PFF.

This PR includes `lgoenlep1` and its associated base variable with domain `community_profiles` to use until we fully build out the replacement language variables for PFF.
