### PR TITLE
Change name of decennial population to not include date

### DIFF
--- a/factfinder/data/metadata.json
+++ b/factfinder/data/metadata.json
@@ -111,8 +111,8 @@
         "source": ""
     },
     {
-        "pff_variable": "popdec",
-        "base_variable": "popdec",
+        "pff_variable": "decennial_pop",
+        "base_variable": "decennial_pop",
         "census_variable": [
             "P001001"
         ],

--- a/factfinder/data/metadata.json
+++ b/factfinder/data/metadata.json
@@ -111,8 +111,8 @@
         "source": ""
     },
     {
-        "pff_variable": "pop2010",
-        "base_variable": "pop2010",
+        "pff_variable": "popdec",
+        "base_variable": "popdec",
         "census_variable": [
             "P001001"
         ],


### PR DESCRIPTION
For community profiles, we pull total decennial population for both 2010 and 2000. This variable should not include versioning in its name.