### PR TITLE
WIP: Restrict profile_only_variables to same base as pff_variable

### DIFF
--- a/factfinder/main.py
+++ b/factfinder/main.py
@@ -54,8 +54,8 @@ class Pff:
             i['pff_variable'] for i in self.metadata 
             if (i['census_variable'][0][0:2] == 'DP' 
                 and len(i['census_variable']) == 1 
-                and i['base_variable'] != i['pff_variable'] 
-                and i['base_variable'] != np.nan)
+                and i['base_variable'] != i['pff_variable']
+                and i['base_variable'] != "nan")
         ]
 
     @cached_property

--- a/factfinder/main.py
+++ b/factfinder/main.py
@@ -52,7 +52,10 @@ class Pff:
     def profile_only_variables(self) -> list: 
         return [
             i['pff_variable'] for i in self.metadata 
-            if (i['census_variable'][0][0:2] == 'DP' and len(i['census_variable']) == 1)
+            if (i['census_variable'][0][0:2] == 'DP' 
+                and len(i['census_variable']) == 1 
+                and i['base_variable'] != i['pff_variable'] 
+                and i['base_variable'] != np.nan)
         ]
 
     @cached_property


### PR DESCRIPTION
#56 

To-do: change the base variables in the metadata to reflect DCP-preferred base.