### PR TITLE
profile only variable should have base_variable = pff_variable

### DIFF
--- a/factfinder/main.py
+++ b/factfinder/main.py
@@ -54,7 +54,7 @@ class Pff:
             i['pff_variable'] for i in self.metadata 
             if (i['census_variable'][0][0:2] == 'DP' 
                 and len(i['census_variable']) == 1 
-                and i['base_variable'] != i['pff_variable']
+                and i['base_variable'] == i['pff_variable']
                 and i['base_variable'] != "nan")
         ]
 


### PR DESCRIPTION
#56
e.g. 
```json
    {
        "pff_variable": "abroad",
        "base_variable": "dfhs2",
        "census_variable": [
            "DP02_0085"
        ],
        "domain": "social",
        "rounding": 0,
        "source": "profile"
    },
```
abroad should not be a profile only variable because pff_variable != base_variable, therefore cannot take PE/PM directly from census API