### PR TITLE
Use tract-level lookup-geo from Population

### DIFF
--- a/factfinder/geography/2010_to_2020.py
+++ b/factfinder/geography/2010_to_2020.py
@@ -20,7 +20,6 @@ class AggregatedGeography:
             dtype="str",
         )
         # Create geoid_tract
-        lookup_geo["county_fips"] = lookup_geo.geoid20.apply(lambda x: str(x)[:5])
         lookup_geo["geoid_tract"] = lookup_geo.geoid20.apply(lambda x: str(x)[:11])
 
         return lookup_geo


### PR DESCRIPTION
CSV version of the [geog relationships](https://github.com/NYCPlanning/db-acs-2020/blob/main/lookups/geo_crosswalks/2020GeogRelate.xlsx) used to create sample output.

This version has fewer columns than the current, but I believe we only use tract-level for 2010 to 2020 calculations.

#151 