### PR TITLE
adding acs 2006-2010 metadata mapping, received from erica

### DIFF
--- a/factfinder/data/acs/2010/metadata.json
+++ b/factfinder/data/acs/2010/metadata.json
@@ -1,7225 +1,13 @@
 [
     {
-        "pff_variable": "pop25t29",
-        "census_variable": [
-            "B01001_035",
-            "B01001_011"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop40t44",
-        "census_variable": [
-            "B01001_014",
-            "B01001_038"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop0t5",
-        "census_variable": [
-            "B01001_027"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fem",
-        "census_variable": [
-            "DP05_0003"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnvtn",
-        "census_variable": [
-            "B02015_022"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop50t54",
-        "census_variable": [
-            "B01001_016",
-            "B01001_040"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspsam",
-        "census_variable": [
-            "B03001_016"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop35t39",
-        "census_variable": [
-            "B01001_013"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspspnsh",
-        "census_variable": [
-            "B03001_029"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnbhutn",
-        "census_variable": [
-            "B02015_004"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop85pl",
-        "census_variable": [
-            "DP05_0017"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop55t59",
-        "census_variable": [
-            "DP05_0013"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop35t39",
-        "census_variable": [
-            "B01001_013",
-            "B01001_037"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop67t69",
-        "census_variable": [
-            "B01001_045",
-            "B01001_021"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop18t19",
-        "census_variable": [
-            "B01001_031",
-            "B01001_007"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnkor",
-        "census_variable": [
-            "B02015_012"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop5t9",
-        "census_variable": [
-            "B01001_004"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnhmng",
-        "census_variable": [
-            "B02015_009"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop20",
-        "census_variable": [
-            "B01001_032",
-            "B01001_008"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop",
-        "census_variable": [
-            "B01001_001"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asneast",
-        "census_variable": [
-            "B02015_015",
-            "B02015_017",
-            "B02015_011",
-            "B02015_007",
-            "B02015_012",
-            "B02015_020"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop_1",
-        "census_variable": [
-            "DP05_0001"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop15t19",
-        "census_variable": [
-            "B01001_006",
-            "B01001_007"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop65pl2",
-        "census_variable": [
-            "DP05_0029"
-        ],
-        "base_variable": "pop65pl2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop80t84",
-        "census_variable": [
-            "B01001_048"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop20t24",
-        "census_variable": [
-            "DP05_0009"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop70t74",
-        "census_variable": [
-            "B01001_022",
-            "B01001_046"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop70t74",
-        "census_variable": [
-            "B01001_046"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hsp2",
-        "census_variable": [
-            "B03001_003"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop75t79",
-        "census_variable": [
-            "B01001_023"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdage",
-        "census_variable": [
-            "DP05_0018"
-        ],
-        "base_variable": "median",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 1
-    },
-    {
-        "pff_variable": "mdpop65t66",
-        "census_variable": [
-            "B01001_044",
-            "B01001_020"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop65plf",
-        "census_variable": [
-            "DP05_0031"
-        ],
-        "base_variable": "pop65pl2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "popu5",
-        "census_variable": [
-            "DP05_0005"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nhsp",
-        "census_variable": [
-            "DP05_0076"
-        ],
-        "base_variable": "pop_2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop20t24",
-        "census_variable": [
-            "B01001_032",
-            "B01001_034",
-            "B01001_033"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnoasn",
-        "census_variable": [
-            "B02015_023",
-            "B02015_024"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspperu",
-        "census_variable": [
-            "B03001_023"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hsppr",
-        "census_variable": [
-            "B03001_005"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop55t59",
-        "census_variable": [
-            "B01001_017"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop21",
-        "census_variable": [
-            "B01001_009",
-            "B01001_033"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop60t64",
-        "census_variable": [
-            "B01001_042",
-            "B01001_043"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnind",
-        "census_variable": [
-            "B02015_002"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspcol",
-        "census_variable": [
-            "B03001_020"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop85pl",
-        "census_variable": [
-            "B01001_025"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop30t34",
-        "census_variable": [
-            "B01001_036",
-            "B01001_012"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnsouth",
-        "census_variable": [
-            "B02015_018",
-            "B02015_019",
-            "B02015_002",
-            "B02015_004",
-            "B02015_016",
-            "B02015_003"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop25t29",
-        "census_variable": [
-            "B01001_011"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspvnz",
-        "census_variable": [
-            "B03001_025"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop_3",
-        "census_variable": [
-            "B01001_001"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "popu18f",
-        "census_variable": [
-            "B05003_014"
-        ],
-        "base_variable": "popu18_2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspec",
-        "census_variable": [
-            "B03001_021"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop25t29",
-        "census_variable": [
-            "B01001_035"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnmgol",
-        "census_variable": [
-            "B02015_015"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop70t74",
-        "census_variable": [
-            "B01001_022"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop35t39",
-        "census_variable": [
-            "B01001_037"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop85pl",
-        "census_variable": [
-            "B01001_049"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nhpinh",
-        "census_variable": [
-            "DP05_0081"
-        ],
-        "base_variable": "pop_2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hsposam",
-        "census_variable": [
-            "B03001_026"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop80t84",
-        "census_variable": [
-            "B01001_024"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop62t64",
-        "census_variable": [
-            "B01001_019",
-            "B01001_043"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop0t5",
-        "census_variable": [
-            "B01001_003"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnsril",
-        "census_variable": [
-            "B02015_019"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop60t64",
-        "census_variable": [
-            "DP05_0014"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop50t54",
-        "census_variable": [
-            "B01001_016",
-            "B01001_040"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop55t59",
-        "census_variable": [
-            "B01001_041"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop80t84",
-        "census_variable": [
-            "B01001_048",
-            "B01001_024"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop_6",
-        "census_variable": [
-            "B01001_001"
-        ],
-        "base_variable": "percapinc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspdom",
-        "census_variable": [
-            "B03001_007"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop15t19",
-        "census_variable": [
-            "DP05_0008"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop65pl1",
-        "census_variable": [
-            "DP05_0024"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop85pl",
-        "census_variable": [
-            "B01001_049",
-            "B01001_025"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspurg",
-        "census_variable": [
-            "B03001_024"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "popu18m",
-        "census_variable": [
-            "B05003_003"
-        ],
-        "base_variable": "popu18_2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop35t39",
-        "census_variable": [
-            "B01001_013",
-            "B01001_037"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop75t79",
-        "census_variable": [
-            "B01001_047",
-            "B01001_023"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnnepal",
-        "census_variable": [
-            "B02015_016"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspchl",
-        "census_variable": [
-            "B03001_019"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspme",
-        "census_variable": [
-            "B03001_004"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop20t24",
-        "census_variable": [
-            "B01001_009",
-            "B01001_008",
-            "B01001_010"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnseast",
-        "census_variable": [
-            "B02015_014",
-            "B02015_021",
-            "B02015_013",
-            "B02015_005",
-            "B02015_022",
-            "B02015_009",
-            "B02015_010",
-            "B02015_008",
-            "B02015_006"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop75t79",
-        "census_variable": [
-            "B01001_047",
-            "B01001_023"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "othnh",
-        "census_variable": [
-            "DP05_0082"
-        ],
-        "base_variable": "pop_2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspcr",
-        "census_variable": [
-            "B03001_009"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asncmb",
-        "census_variable": [
-            "B02015_006"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspalloth",
-        "census_variable": [
-            "B03001_031"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop40t44",
-        "census_variable": [
-            "B01001_038"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hsppan",
-        "census_variable": [
-            "B03001_013"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop10t14",
-        "census_variable": [
-            "DP05_0007"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnpak",
-        "census_variable": [
-            "B02015_018"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop65t69",
-        "census_variable": [
-            "B01001_044",
-            "B01001_045"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop10t14",
-        "census_variable": [
-            "B01001_005",
-            "B01001_029"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "wtnh",
-        "census_variable": [
-            "DP05_0077"
-        ],
-        "base_variable": "pop_2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnburm",
-        "census_variable": [
-            "B02015_005"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnflp",
-        "census_variable": [
-            "B02015_008"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop70t74",
-        "census_variable": [
-            "B01001_022",
-            "B01001_046"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop40t44",
-        "census_variable": [
-            "B01001_014",
-            "B01001_038"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hsp1",
-        "census_variable": [
-            "DP05_0071"
-        ],
-        "base_variable": "pop_2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hsphnd",
-        "census_variable": [
-            "B03001_011"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop65t69",
-        "census_variable": [
-            "B01001_044",
-            "B01001_045",
-            "B01001_021",
-            "B01001_020"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnindnsn",
-        "census_variable": [
-            "B02015_010"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop30t34",
-        "census_variable": [
-            "B01001_036"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop75t79",
-        "census_variable": [
-            "B01001_047"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "popu18_2",
-        "census_variable": [
-            "DP05_0019"
-        ],
-        "base_variable": "popu18_2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop80t84",
-        "census_variable": [
-            "B01001_048",
-            "B01001_024"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop50t54",
-        "census_variable": [
-            "B01001_040"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop55t59",
-        "census_variable": [
-            "B01001_041",
-            "B01001_017"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspguatm",
-        "census_variable": [
-            "B03001_010"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop45t49",
-        "census_variable": [
-            "B01001_039"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspcub",
-        "census_variable": [
-            "B03001_006"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspcam",
-        "census_variable": [
-            "B03001_008"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspspnrd",
-        "census_variable": [
-            "B03001_028"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspsalv",
-        "census_variable": [
-            "B03001_014"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop50t54",
-        "census_variable": [
-            "B01001_016"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnjpn",
-        "census_variable": [
-            "B02015_011"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnthai",
-        "census_variable": [
-            "B02015_021"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asn2pl",
-        "census_variable": [
-            "B02015_025"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asntwn",
-        "census_variable": [
-            "B02015_020"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnbng",
-        "census_variable": [
-            "B02015_003"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop15t19",
-        "census_variable": [
-            "B01001_031",
-            "B01001_030"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspspam",
-        "census_variable": [
-            "B03001_030"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnlao",
-        "census_variable": [
-            "B02015_013"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "aiannh",
-        "census_variable": [
-            "DP05_0079"
-        ],
-        "base_variable": "pop_2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspprg",
-        "census_variable": [
-            "B03001_022"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop0t4",
-        "census_variable": [
-            "B01001_027",
-            "B01001_003"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "popu181",
-        "census_variable": [
-            "DP05_0019"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspocam",
-        "census_variable": [
-            "B03001_015"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop10t14",
-        "census_variable": [
-            "B01001_005"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop45t49",
-        "census_variable": [
-            "B01001_015"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnmalsn",
-        "census_variable": [
-            "B02015_014"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop_2",
-        "census_variable": [
-            "DP05_0070"
-        ],
-        "base_variable": "pop_2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop30t34",
-        "census_variable": [
-            "B01001_012"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop60t64",
-        "census_variable": [
-            "B01001_019",
-            "B01001_018"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop30t34",
-        "census_variable": [
-            "B01001_036",
-            "B01001_012"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop5t9",
-        "census_variable": [
-            "B01001_028",
-            "B01001_004"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop60t61",
-        "census_variable": [
-            "B01001_042",
-            "B01001_018"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnchinot",
-        "census_variable": [
-            "B02015_007"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop40t44",
-        "census_variable": [
-            "B01001_014"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop22t24",
-        "census_variable": [
-            "B01001_010",
-            "B01001_034"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "blnh",
-        "census_variable": [
-            "DP05_0078"
-        ],
-        "base_variable": "pop_2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnnh",
-        "census_variable": [
-            "DP05_0080"
-        ],
-        "base_variable": "pop_2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop15t17",
-        "census_variable": [
-            "B01001_006",
-            "B01001_030"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspbol",
-        "census_variable": [
-            "B03001_018"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rc2plnh",
-        "census_variable": [
-            "DP05_0083"
-        ],
-        "base_variable": "pop_2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop45t49",
-        "census_variable": [
-            "B01001_015",
-            "B01001_039"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop65plm",
-        "census_variable": [
-            "DP05_0030"
-        ],
-        "base_variable": "pop65pl2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop5t9",
-        "census_variable": [
-            "DP05_0006"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspnic",
-        "census_variable": [
-            "B03001_012"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hsparg",
-        "census_variable": [
-            "B03001_017"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hspoth",
-        "census_variable": [
-            "B03001_027"
-        ],
-        "base_variable": "hsp2",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "male",
-        "census_variable": [
-            "DP05_0002"
-        ],
-        "base_variable": "pop_1",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop10t14",
-        "census_variable": [
-            "B01001_029"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop65t69",
-        "census_variable": [
-            "B01001_021",
-            "B01001_020"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop25t29",
-        "census_variable": [
-            "B01001_035",
-            "B01001_011"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop45t49",
-        "census_variable": [
-            "B01001_015",
-            "B01001_039"
-        ],
-        "base_variable": "mdage",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop5t9",
-        "census_variable": [
-            "B01001_028"
-        ],
-        "base_variable": "pop",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asnokinw",
-        "census_variable": [
-            "B02015_017"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asn1rc",
-        "census_variable": [
-            "B02015_001"
-        ],
-        "base_variable": "asn1rc",
-        "domain": "demographic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvnid_hrg",
-        "census_variable": [
-            "S1810_C01_019"
-        ],
-        "base_variable": "cvnipop1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ea_grdpfd",
-        "census_variable": [
-            "DP02_0065"
-        ],
-        "base_variable": "ea_p25pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "seasia",
-        "census_variable": [
-            "B05006_067"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "c65pldvsn",
-        "census_variable": [
-            "S1810_C01_036"
-        ],
-        "base_variable": "cvni65pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oweur",
-        "census_variable": [
-            "B05006_020"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vietnam",
-        "census_variable": [
-            "B05006_076"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ms_fnvmrd",
-        "census_variable": [
-            "DP02_0031"
-        ],
-        "base_variable": "ms_f15pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nigeria",
-        "census_variable": [
-            "B05006_113"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "neurpn",
-        "census_variable": [
-            "B04006_058"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "alsatn",
-        "census_variable": [
-            "B04006_004"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oausnzsbr",
-        "census_variable": [
-            "B05006_120"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ea_hscgrd",
-        "census_variable": [
-            "DP02_0061"
-        ],
-        "base_variable": "ea_p25pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nthrlds",
-        "census_variable": [
-            "B05006_018"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oseasia",
-        "census_variable": [
-            "B05006_077"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fiji",
-        "census_variable": [
-            "B05006_121"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ghanaian",
-        "census_variable": [
-            "B04006_076"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "croatia",
-        "census_variable": [
-            "B05006_032"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "european",
-        "census_variable": [
-            "B04006_038"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "malaysia",
-        "census_variable": [
-            "B05006_071"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "dhdfcntnyc",
-        "census_variable": [
-            "B07204_006"
-        ],
-        "base_variable": "dfhs2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "lthian",
-        "census_variable": [
-            "B04006_053"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "lthuania",
-        "census_variable": [
-            "B05006_036"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fhnh",
-        "census_variable": [
-            "DP02_0008"
-        ],
-        "base_variable": "hh1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "india",
-        "census_variable": [
-            "B05006_059"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "osthrnafr",
-        "census_variable": [
-            "B05006_108"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "jrdnian",
-        "census_variable": [
-            "B04006_009"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "israeli",
-        "census_variable": [
-            "B04006_050"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "egypt",
-        "census_variable": [
-            "B05006_102"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ms_fmrdsp",
-        "census_variable": [
-            "DP02_0032"
-        ],
-        "base_variable": "ms_f15pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "english",
-        "census_variable": [
-            "B04006_036"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvnid_cog",
-        "census_variable": [
-            "S1810_C01_039"
-        ],
-        "base_variable": "cvnipop1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rshp_sp",
-        "census_variable": [
-            "DP02_0019"
-        ],
-        "base_variable": "hhpop",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ethpian",
-        "census_variable": [
-            "B04006_075"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cu18dvsn",
-        "census_variable": [
-            "S1810_C01_030"
-        ],
-        "base_variable": "cvniu18_1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvvet18pl",
-        "census_variable": [
-            "DP02_0069"
-        ],
-        "base_variable": "cvpop18pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "liberian",
-        "census_variable": [
-            "B04006_078"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "smhs",
-        "census_variable": [
-            "DP02_0079"
-        ],
-        "base_variable": "pop1pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "german",
-        "census_variable": [
-            "B04006_042"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oeafr",
-        "census_variable": [
-            "B05006_097",
-            "B05006_096"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ms_fsp",
-        "census_variable": [
-            "DP02_0033"
-        ],
-        "base_variable": "ms_f15pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oseur",
-        "census_variable": [
-            "B05006_027"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "zmbwean",
-        "census_variable": [
-            "B04006_086"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "syria",
-        "census_variable": [
-            "B05006_085"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "sudanese",
-        "census_variable": [
-            "B04006_084"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "somali",
-        "census_variable": [
-            "B04006_082"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "morocco",
-        "census_variable": [
-            "B05006_103"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ntvus",
-        "census_variable": [
-            "DP02_0088"
-        ],
-        "base_variable": "pop_4",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "sierral",
-        "census_variable": [
-            "B05006_114"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "osubsafr",
-        "census_variable": [
-            "B04006_088"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oneur",
-        "census_variable": [
-            "B05006_012"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "lam",
-        "census_variable": [
-            "B05006_124"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "onam",
-        "census_variable": [
-            "B05006_162"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ms_mnvmrd",
-        "census_variable": [
-            "DP02_0025"
-        ],
-        "base_variable": "ms_m15pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "bulgaria",
-        "census_variable": [
-            "B05006_031"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "colombia",
-        "census_variable": [
-            "B05006_153"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "austrlia",
-        "census_variable": [
-            "B05006_119"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ukraine",
-        "census_variable": [
-            "B05006_042"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "avgfmsz",
-        "census_variable": [
-            "DP02_0016"
-        ],
-        "base_variable": "mean",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ms_msp",
-        "census_variable": [
-            "DP02_0027"
-        ],
-        "base_variable": "ms_m15pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop_4",
-        "census_variable": [
-            "DP02_0086"
-        ],
-        "base_variable": "pop_4",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nzealnd",
-        "census_variable": [
-            "B04006_057"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "czechslv",
-        "census_variable": [
-            "B04006_032"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "burma",
-        "census_variable": [
-            "B05006_072"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "thailand",
-        "census_variable": [
-            "B05006_075"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "belizean",
-        "census_variable": [
-            "B04006_097"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "unclsnr",
-        "census_variable": [
-            "B04006_109"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hhcomp",
-        "census_variable": [
-            "DP02_0151"
-        ],
-        "base_variable": "hh3",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "eritrea",
-        "census_variable": [
-            "B05006_093"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "se_g1t8",
-        "census_variable": [
-            "DP02_0055"
-        ],
-        "base_variable": "pop3plen",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "croatian",
-        "census_variable": [
-            "B04006_029"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "windsub",
-        "census_variable": [
-            "B04006_105"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "afghan",
-        "census_variable": [
-            "B05006_057"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "greece",
-        "census_variable": [
-            "B05006_022"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "c1864damb",
-        "census_variable": [
-            "S1810_C01_049"
-        ],
-        "base_variable": "cni1864_1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cam",
-        "census_variable": [
-            "B05006_138"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cstarica",
-        "census_variable": [
-            "B05006_141"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rshp_ssup",
-        "census_variable": [
-            "B11009_003",
-            "B11009_005"
-        ],
-        "base_variable": "hhpop",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mhnw",
-        "census_variable": [
-            "DP02_0006"
-        ],
-        "base_variable": "hh1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fbntlzd",
-        "census_variable": [
-            "DP02_0094"
-        ],
-        "base_variable": "fb3",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ms_f15pl",
-        "census_variable": [
-            "DP02_0030"
-        ],
-        "base_variable": "ms_f15pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "frcandian",
-        "census_variable": [
-            "B04006_041"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "c65pldhrg",
-        "census_variable": [
-            "S1810_C01_026"
-        ],
-        "base_variable": "cvni65pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "jordan",
-        "census_variable": [
-            "B05006_081"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "slovak",
-        "census_variable": [
-            "B04006_070"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "jamaica",
-        "census_variable": [
-            "B05006_133"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oeeur",
-        "census_variable": [
-            "B05006_045"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ea_ascd",
-        "census_variable": [
-            "DP02_0063"
-        ],
-        "base_variable": "ea_p25pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "portgese",
-        "census_variable": [
-            "B04006_062"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "dchwind",
-        "census_variable": [
-            "B04006_100"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "seur",
-        "census_variable": [
-            "B05006_021"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "wafr",
-        "census_variable": [
-            "B05006_109"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ntv",
-        "census_variable": [
-            "DP02_0087"
-        ],
-        "base_variable": "pop_4",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "germany",
-        "census_variable": [
-            "B05006_017"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cu18dcog",
-        "census_variable": [
-            "S1810_C01_040"
-        ],
-        "base_variable": "cvniu18_1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "belarus",
-        "census_variable": [
-            "B05006_030"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "austrln",
-        "census_variable": [
-            "B04006_018"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hh1pl65pl",
-        "census_variable": [
-            "DP02_0014"
-        ],
-        "base_variable": "hh1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "belgium",
-        "census_variable": [
-            "B05006_015"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asianec",
-        "census_variable": [
-            "B05006_090"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "taiwan",
-        "census_variable": [
-            "B05006_052"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "uknoengsc",
-        "census_variable": [
-            "B05006_005"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mafr",
-        "census_variable": [
-            "B05006_098"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "bahamas",
-        "census_variable": [
-            "B05006_126"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fam1",
-        "census_variable": [
-            "DP02_0002"
-        ],
-        "base_variable": "hh1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "finnish",
-        "census_variable": [
-            "B04006_039"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oscasia",
-        "census_variable": [
-            "B05006_066"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "elslvdr",
-        "census_variable": [
-            "B05006_142"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "tandtob",
-        "census_variable": [
-            "B04006_103"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvnipop1",
-        "census_variable": [
-            "DP02_0070"
-        ],
-        "base_variable": "cvnipop1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "untdkgdm",
-        "census_variable": [
-            "B05006_004"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "belize",
-        "census_variable": [
-            "B05006_140"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mrdfam",
-        "census_variable": [
-            "DP02_0004"
-        ],
-        "base_variable": "hh1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "portugal",
-        "census_variable": [
-            "B05006_024"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "sudan",
-        "census_variable": [
-            "B05006_104"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "serbian",
-        "census_variable": [
-            "B04006_068"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fb1",
-        "census_variable": [
-            "DP02_0092"
-        ],
-        "base_variable": "pop_4",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "avghhsz",
-        "census_variable": [
-            "DP02_0015"
-        ],
-        "base_variable": "mean",
-        "domain": "social",
-        "source": "",
-        "rounding": 2
-    },
-    {
-        "pff_variable": "ntvprusab",
-        "census_variable": [
-            "DP02_0091"
-        ],
-        "base_variable": "pop_4",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nfama",
-        "census_variable": [
-            "DP02_0011"
-        ],
-        "base_variable": "hh1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cu18dscr",
-        "census_variable": [
-            "S1810_C01_056"
-        ],
-        "base_variable": "cvniu18_1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvrdean",
-        "census_variable": [
-            "B04006_074"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "bulgrian",
-        "census_variable": [
-            "B04006_024"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rshp_nrup",
-        "census_variable": [
-            "DP02_0023"
-        ],
-        "base_variable": "hhpop",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "owasia",
-        "census_variable": [
-            "B05006_089"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "abroad",
-        "census_variable": [
-            "DP02_0085"
-        ],
-        "base_variable": "dfhs2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ecuador",
-        "census_variable": [
-            "B05006_154"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "luxmbgr",
-        "census_variable": [
-            "B04006_054"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "usvrgis",
-        "census_variable": [
-            "B04006_104"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cypriot",
-        "census_variable": [
-            "B04006_030"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "eng",
-        "census_variable": [
-            "B05006_006"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "sctchirsh",
-        "census_variable": [
-            "B04006_066"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "c1864dvsn",
-        "census_variable": [
-            "S1810_C01_033"
-        ],
-        "base_variable": "cni1864_1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "c1864dscr",
-        "census_variable": [
-            "S1810_C01_057"
-        ],
-        "base_variable": "cni1864_1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "sngapore",
-        "census_variable": [
-            "B05006_074"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "svtunion",
-        "census_variable": [
-            "B04006_072"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asyrchlds",
-        "census_variable": [
-            "B04006_017"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "grenada",
-        "census_variable": [
-            "B05006_131"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rshp_ch",
-        "census_variable": [
-            "DP02_0020"
-        ],
-        "base_variable": "hhpop",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "brzlian",
-        "census_variable": [
-            "B04006_022"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "armenia",
-        "census_variable": [
-            "B05006_088"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "egyptn",
-        "census_variable": [
-            "B04006_007"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "yugoslv",
-        "census_variable": [
-            "B04006_107"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "irish",
-        "census_variable": [
-            "B04006_049"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "dfhsdfcnt",
-        "census_variable": [
-            "DP02_0082"
-        ],
-        "base_variable": "dfhs2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "czech",
-        "census_variable": [
-            "B04006_031"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ghana",
-        "census_variable": [
-            "B05006_111"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "japan",
-        "census_variable": [
-            "B05006_053"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "eeur",
-        "census_variable": [
-            "B05006_028"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "brtwind",
-        "census_variable": [
-            "B04006_099"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ea_sclgnd",
-        "census_variable": [
-            "DP02_0062"
-        ],
-        "base_variable": "ea_p25pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "brbdian",
-        "census_variable": [
-            "B04006_096"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oeasia",
-        "census_variable": [
-            "B05006_055"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "laos",
-        "census_variable": [
-            "B05006_070"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nicargua",
-        "census_variable": [
-            "B05006_145"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvnid_vsn",
-        "census_variable": [
-            "S1810_C01_029"
-        ],
-        "base_variable": "cvnipop1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "dfhs2",
-        "census_variable": [
-            "B07204_016",
-            "B07204_003"
-        ],
-        "base_variable": "dfhs2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "norway",
-        "census_variable": [
-            "B05006_010"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "greek",
-        "census_variable": [
-            "B04006_044"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "poland",
-        "census_variable": [
-            "B05006_039"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "albania",
-        "census_variable": [
-            "B05006_029"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ocam",
-        "census_variable": [
-            "B05006_147"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "bngldsh",
-        "census_variable": [
-            "B05006_058"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ocnianec",
-        "census_variable": [
-            "B05006_122"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "domrep",
-        "census_variable": [
-            "B05006_130"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ms_fwd",
-        "census_variable": [
-            "DP02_0034"
-        ],
-        "base_variable": "ms_f15pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvniu18d",
-        "census_variable": [
-            "DP02_0073"
-        ],
-        "base_variable": "cvniu18_1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "c1864dhrg",
-        "census_variable": [
-            "S1810_C01_023"
-        ],
-        "base_variable": "cni1864_1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "onafr",
-        "census_variable": [
-            "B05006_105"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvniu18_1",
-        "census_variable": [
-            "DP02_0072"
-        ],
-        "base_variable": "cvniu18_1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "sleonean",
-        "census_variable": [
-            "B04006_081"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "romanian",
-        "census_variable": [
-            "B04006_063"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "brazil",
-        "census_variable": [
-            "B05006_151"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nepal",
-        "census_variable": [
-            "B05006_062"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rshp_nr",
-        "census_variable": [
-            "DP02_0022"
-        ],
-        "base_variable": "hhpop",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "alb",
-        "census_variable": [
-            "B04006_003"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hh1",
-        "census_variable": [
-            "DP02_0001"
-        ],
-        "base_variable": "hh1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hungary",
-        "census_variable": [
-            "B05006_034"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "amercn",
-        "census_variable": [
-            "B04006_005"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "caboverd",
-        "census_variable": [
-            "B05006_110"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "honduras",
-        "census_variable": [
-            "B05006_144"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "macdnian",
-        "census_variable": [
-            "B04006_055"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oarab",
-        "census_variable": [
-            "B04006_015"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "germrus",
-        "census_variable": [
-            "B04006_043"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ea_p25pl",
-        "census_variable": [
-            "DP02_0058"
-        ],
-        "base_variable": "ea_p25pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "windies",
-        "census_variable": [
-            "B05006_136"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cni18t64d",
-        "census_variable": [
-            "DP02_0075"
-        ],
-        "base_variable": "cni1864_1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "weur",
-        "census_variable": [
-            "B05006_013"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "gplgcu18",
-        "census_variable": [
-            "DP02_0043"
-        ],
-        "base_variable": "gplgcu18",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "owafr",
-        "census_variable": [
-            "B05006_115"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nfam1",
-        "census_variable": [
-            "DP02_0010"
-        ],
-        "base_variable": "hh1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "polish",
-        "census_variable": [
-            "B04006_061"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "eeurpn",
-        "census_variable": [
-            "B04006_035"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "romania",
-        "census_variable": [
-            "B05006_040"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ea_bchdh",
-        "census_variable": [
-            "DP02_0065",
-            "DP02_0064",
-            "DP02_0067"
-        ],
-        "base_variable": "ea_p25pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "c65pldild",
-        "census_variable": [
-            "S1810_C01_067"
-        ],
-        "base_variable": "cvni65pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cameroon",
-        "census_variable": [
-            "B05006_099"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "dfhs1",
-        "census_variable": [
-            "B07204_016",
-            "B07204_003"
-        ],
-        "base_variable": "pop1pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "belgian",
-        "census_variable": [
-            "B04006_021"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fbnotczn",
-        "census_variable": [
-            "DP02_0095"
-        ],
-        "base_variable": "fb3",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "arabsub",
-        "census_variable": [
-            "B04006_014"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "iraq",
-        "census_variable": [
-            "B05006_079"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "asia",
-        "census_variable": [
-            "B05006_047"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pakistan",
-        "census_variable": [
-            "B05006_063"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hhpop",
-        "census_variable": [
-            "DP02_0017"
-        ],
-        "base_variable": "hhpop",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvni65pld",
-        "census_variable": [
-            "DP02_0077"
-        ],
-        "base_variable": "cvni65pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "dfhsus",
-        "census_variable": [
-            "DP02_0080"
-        ],
-        "base_variable": "dfhs2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "russia",
-        "census_variable": [
-            "B05006_041"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "bosniah",
-        "census_variable": [
-            "B05006_043"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "italy",
-        "census_variable": [
-            "B05006_023"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hongkong",
-        "census_variable": [
-            "B05006_051"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "korea",
-        "census_variable": [
-            "B05006_054"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "kzkhstan",
-        "census_variable": [
-            "B05006_061"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "denmark",
-        "census_variable": [
-            "B05006_009"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "stvgren",
-        "census_variable": [
-            "B05006_134"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "arab",
-        "census_variable": [
-            "B04006_006"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "wasia",
-        "census_variable": [
-            "B05006_078"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "neur",
-        "census_variable": [
-            "B05006_003"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "maltese",
-        "census_variable": [
-            "B04006_056"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "sam",
-        "census_variable": [
-            "B05006_148"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "swiss",
-        "census_variable": [
-            "B04006_090"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ugandan",
-        "census_variable": [
-            "B04006_085"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "dfhssmcnt",
-        "census_variable": [
-            "DP02_0081"
-        ],
-        "base_variable": "dfhs2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "srilanka",
-        "census_variable": [
-            "B05006_064"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ireland",
-        "census_variable": [
-            "B05006_008"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nafr",
-        "census_variable": [
-            "B05006_101"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mrdchu18",
-        "census_variable": [
-            "DP02_0005"
-        ],
-        "base_variable": "hh1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "kenyan",
-        "census_variable": [
-            "B04006_077"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "moroccan",
-        "census_variable": [
-            "B04006_011"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "haiti",
-        "census_variable": [
-            "B05006_132"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "iraqi",
-        "census_variable": [
-            "B04006_008"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "uzbkstan",
-        "census_variable": [
-            "B05006_065"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ea_bchd",
-        "census_variable": [
-            "DP02_0064"
-        ],
-        "base_variable": "ea_p25pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cni1864_1",
-        "census_variable": [
-            "DP02_0074"
-        ],
-        "base_variable": "cni1864_1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "czchslv",
-        "census_variable": [
-            "B05006_033"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "guyanese",
-        "census_variable": [
-            "B04006_045"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ea_9t12nd",
-        "census_variable": [
-            "DP02_0060"
-        ],
-        "base_variable": "ea_p25pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "scot",
-        "census_variable": [
-            "B05006_007"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "kenya",
-        "census_variable": [
-            "B05006_095"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvni65pl",
-        "census_variable": [
-            "DP02_0076"
-        ],
-        "base_variable": "cvni65pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvnid_amb",
-        "census_variable": [
-            "S1810_C01_047"
-        ],
-        "base_variable": "cvnipop1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mcdonia",
-        "census_variable": [
-            "B05006_037"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "se_g9t12",
-        "census_variable": [
-            "DP02_0056"
-        ],
-        "base_variable": "pop3plen",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "frnotbsq",
-        "census_variable": [
-            "B04006_040"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "syrian",
-        "census_variable": [
-            "B04006_013"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvpop18pl",
-        "census_variable": [
-            "DP02_0068"
-        ],
-        "base_variable": "cvpop18pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "jamaican",
-        "census_variable": [
-            "B04006_102"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "c1864dild",
-        "census_variable": [
-            "S1810_C01_064"
-        ],
-        "base_variable": "cni1864_1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fb3",
-        "census_variable": [
-            "DP02_0093"
-        ],
-        "base_variable": "fb3",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "se_clggsc",
-        "census_variable": [
-            "DP02_0057"
-        ],
-        "base_variable": "pop3plen",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "osam",
-        "census_variable": [
-            "B05006_159"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvnid",
-        "census_variable": [
-            "DP02_0071"
-        ],
-        "base_variable": "cvnipop1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "carprusn",
-        "census_variable": [
-            "B04006_027"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "switzrld",
-        "census_variable": [
-            "B05006_019"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "afg",
-        "census_variable": [
-            "B04006_002"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "carib",
-        "census_variable": [
-            "B05006_125"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cu18damb",
-        "census_variable": [
-            "S1810_C01_048"
-        ],
-        "base_variable": "cvniu18_1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hh1plu18",
-        "census_variable": [
-            "DP02_0013"
-        ],
-        "base_variable": "hh1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "china",
-        "census_variable": [
-            "B05006_049"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "british",
-        "census_variable": [
-            "B04006_023"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ms_mwd",
-        "census_variable": [
-            "DP02_0028"
-        ],
-        "base_variable": "ms_m15pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "snglese",
-        "census_variable": [
-            "B04006_080"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oceania",
-        "census_variable": [
-            "B05006_117"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "russian",
-        "census_variable": [
-            "B04006_064"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "gprgcu18",
-        "census_variable": [
-            "DP02_0044"
-        ],
-        "base_variable": "gplgcu18",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ocarib",
-        "census_variable": [
-            "B05006_137"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "norwgian",
-        "census_variable": [
-            "B04006_059"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "sweden",
-        "census_variable": [
-            "B05006_011"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "trandtob",
-        "census_variable": [
-            "B05006_135"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "kuwait",
-        "census_variable": [
-            "B05006_082"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvnid_scr",
-        "census_variable": [
-            "S1810_C01_055"
-        ],
-        "base_variable": "cvnipop1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "palstnian",
-        "census_variable": [
-            "B04006_012"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "easia",
-        "census_variable": [
-            "B05006_048"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "c65pldamb",
-        "census_variable": [
-            "S1810_C01_052"
-        ],
-        "base_variable": "cvni65pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "celtic",
-        "census_variable": [
-            "B04006_028"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "subsaf",
-        "census_variable": [
-            "B04006_073"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "scandnvn",
-        "census_variable": [
-            "B04006_065"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ms_m15pl",
-        "census_variable": [
-            "DP02_0024"
-        ],
-        "base_variable": "ms_m15pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "chnohktwn",
-        "census_variable": [
-            "B05006_050"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ms_mmrdsp",
-        "census_variable": [
-            "DP02_0026"
-        ],
-        "base_variable": "ms_m15pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "othr",
-        "census_variable": [
-            "B04006_108"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "israel",
-        "census_variable": [
-            "B05006_080"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "canadian",
-        "census_variable": [
-            "B04006_026"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "dhnonyc",
-        "census_variable": [
-            "B07204_009"
-        ],
-        "base_variable": "dfhs2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "liberia",
-        "census_variable": [
-            "B05006_112"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "popinfms",
-        "census_variable": [
-            "B11002_007",
-            "B11002_010",
-            "B11002_004"
-        ],
-        "base_variable": "avgfmsz",
-        "domain": "social",
-        "source": "",
-        "rounding": 2
-    },
-    {
-        "pff_variable": "sthrnafr",
-        "census_variable": [
-            "B05006_106"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "panama",
-        "census_variable": [
-            "B05006_146"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cambodia",
-        "census_variable": [
-            "B05006_068"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "c65pldscr",
-        "census_variable": [
-            "S1810_C01_060"
-        ],
-        "base_variable": "cvni65pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "moldova",
-        "census_variable": [
-            "B05006_038"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "c65pldcog",
-        "census_variable": [
-            "S1810_C01_044"
-        ],
-        "base_variable": "cvni65pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fb2",
-        "census_variable": [
-            "DP02_0092"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "haitian",
-        "census_variable": [
-            "B04006_101"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop_5",
-        "census_variable": [
-            "DP02_0122"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "c1864dcog",
-        "census_variable": [
-            "S1810_C01_041"
-        ],
-        "base_variable": "cni1864_1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "latvian",
-        "census_variable": [
-            "B04006_052"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ukrnian",
-        "census_variable": [
-            "B04006_092"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "latvia",
-        "census_variable": [
-            "B05006_035"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ea_lt9g",
-        "census_variable": [
-            "DP02_0059"
-        ],
-        "base_variable": "ea_p25pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nigerian",
-        "census_variable": [
-            "B04006_079"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "turkey",
-        "census_variable": [
-            "B05006_087"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "windnhsp",
-        "census_variable": [
-            "B04006_094"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "dominica",
-        "census_variable": [
-            "B05006_129"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cu18dhrg",
-        "census_variable": [
-            "S1810_C01_020"
-        ],
-        "base_variable": "cvniu18_1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ntvnys",
-        "census_variable": [
-            "DP02_0089"
-        ],
-        "base_variable": "pop_4",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ntvnotnys",
-        "census_variable": [
-            "DP02_0090"
-        ],
-        "base_variable": "pop_4",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "afr",
-        "census_variable": [
-            "B05006_091"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "indnsia",
-        "census_variable": [
-            "B05006_069"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "danish",
-        "census_variable": [
-            "B04006_033"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ethiopia",
-        "census_variable": [
-            "B05006_094"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "penngerm",
-        "census_variable": [
-            "B04006_060"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "argntina",
-        "census_variable": [
-            "B05006_149"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "peru",
-        "census_variable": [
-            "B05006_156"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "scottish",
-        "census_variable": [
-            "B04006_067"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "icelndr",
-        "census_variable": [
-            "B04006_047"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "barbados",
-        "census_variable": [
-            "B05006_127"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "swedish",
-        "census_variable": [
-            "B04006_089"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cajun",
-        "census_variable": [
-            "B04006_025"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fb2000ltr",
-        "census_variable": [
-            "B05005_004",
-            "B05005_009"
-        ],
-        "base_variable": "fb4",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "scasia",
-        "census_variable": [
-            "B05006_056"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop3plen",
-        "census_variable": [
-            "DP02_0052"
-        ],
-        "base_variable": "pop3plen",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "guyana",
-        "census_variable": [
-            "B05006_155"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vnzuela",
-        "census_variable": [
-            "B05006_158"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mhnwchu18",
-        "census_variable": [
-            "DP02_0007"
-        ],
-        "base_variable": "hh1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "dutch",
-        "census_variable": [
-            "B04006_034"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "african",
-        "census_variable": [
-            "B04006_087"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "bolivia",
-        "census_variable": [
-            "B05006_150"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "slavic",
-        "census_variable": [
-            "B04006_069"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "owind",
-        "census_variable": [
-            "B04006_106"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "omafr",
-        "census_variable": [
-            "B05006_100"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hh3",
-        "census_variable": [
-            "DP02_0150"
-        ],
-        "base_variable": "hh3",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "chile",
-        "census_variable": [
-            "B05006_152"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "se_nscpsc",
-        "census_variable": [
-            "DP02_0053"
-        ],
-        "base_variable": "pop3plen",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "bahamian",
-        "census_variable": [
-            "B04006_095"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "eafr",
-        "census_variable": [
-            "B05006_092"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fb4",
-        "census_variable": [
-            "DP02_0100"
-        ],
-        "base_variable": "fb4",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fhnhchu18",
-        "census_variable": [
-            "DP02_0009"
-        ],
-        "base_variable": "hh1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hhint",
-        "census_variable": [
-            "DP02_0152"
-        ],
-        "base_variable": "hh3",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "armenian",
-        "census_variable": [
-            "B04006_016"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "iranian",
-        "census_variable": [
-            "B04006_048"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "basque",
-        "census_variable": [
-            "B04006_020"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "welsh",
-        "census_variable": [
-            "B04006_093"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "uruguay",
-        "census_variable": [
-            "B05006_157"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nfama65pl",
-        "census_variable": [
-            "DP02_0012"
-        ],
-        "base_variable": "hh1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "iran",
-        "census_variable": [
-            "B05006_060"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "famchu18",
-        "census_variable": [
-            "DP02_0003"
-        ],
-        "base_variable": "hh1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mexico",
-        "census_variable": [
-            "B05006_139"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "italian",
-        "census_variable": [
-            "B04006_051"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ausnzsbr",
-        "census_variable": [
-            "B05006_118"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ea_lthsgr",
-        "census_variable": [
-            "DP02_0059",
-            "DP02_0060"
-        ],
-        "base_variable": "ea_p25pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "eurnec",
-        "census_variable": [
-            "B05006_046"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "france",
-        "census_variable": [
-            "B05006_016"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvnid_ild",
-        "census_variable": [
-            "S1810_C01_063"
-        ],
-        "base_variable": "cvnipop1",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "spain",
-        "census_variable": [
-            "B05006_026"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hhpop1",
-        "census_variable": [
-            "B11002_001"
-        ],
-        "base_variable": "avghhsz",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rshphhldr",
-        "census_variable": [
-            "DP02_0018"
-        ],
-        "base_variable": "hhpop",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "lebanese",
-        "census_variable": [
-            "B04006_010"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "turkish",
-        "census_variable": [
-            "B04006_091"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "amricas",
-        "census_variable": [
-            "B05006_123"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "estonian",
-        "census_variable": [
-            "B04006_037"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "afrnec",
-        "census_variable": [
-            "B05006_116"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rshp_othr",
-        "census_variable": [
-            "DP02_0021"
-        ],
-        "base_variable": "hhpop",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "austria",
-        "census_variable": [
-            "B05006_014"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "canada",
-        "census_variable": [
-            "B05006_161"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ms_mdvcd",
-        "census_variable": [
-            "DP02_0029"
-        ],
-        "base_variable": "ms_m15pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ms_fdvcd",
-        "census_variable": [
-            "DP02_0035"
-        ],
-        "base_variable": "ms_f15pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cuba",
-        "census_variable": [
-            "B05006_128"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "yemen",
-        "census_variable": [
-            "B05006_086"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "eur",
-        "census_variable": [
-            "B05006_002"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "se_kndgtn",
-        "census_variable": [
-            "DP02_0054"
-        ],
-        "base_variable": "pop3plen",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fam3",
-        "census_variable": [
-            "DP02_0002"
-        ],
-        "base_variable": "avgfmsz",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "guatmala",
-        "census_variable": [
-            "B05006_143"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop1pl",
-        "census_variable": [
-            "DP02_0078"
-        ],
-        "base_variable": "pop1pl",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hh4",
-        "census_variable": [
-            "DP02_0001"
-        ],
-        "base_variable": "avghhsz",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "philipns",
-        "census_variable": [
-            "B05006_073"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "safrican",
-        "census_variable": [
-            "B04006_083"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hgrian",
-        "census_variable": [
-            "B04006_046"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "austrian",
-        "census_variable": [
-            "B04006_019"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "sthafrca",
-        "census_variable": [
-            "B05006_107"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "saudiar",
-        "census_variable": [
-            "B05006_084"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nam",
-        "census_variable": [
-            "B05006_160"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "slovene",
-        "census_variable": [
-            "B04006_071"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "lebanon",
-        "census_variable": [
-            "B05006_083"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "bermudan",
-        "census_variable": [
-            "B04006_098"
-        ],
-        "base_variable": "pop_5",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "serbia",
-        "census_variable": [
-            "B05006_044"
-        ],
-        "base_variable": "fb2",
-        "domain": "social",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vhcl1av",
-        "census_variable": [
-            "DP04_0059"
-        ],
-        "base_variable": "ochu4",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ochu4",
-        "census_variable": [
-            "DP04_0057"
-        ],
-        "base_variable": "ochu4",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hu3",
-        "census_variable": [
-            "DP04_0016"
-        ],
-        "base_variable": "hu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "blt50t59",
-        "census_variable": [
-            "DP04_0024"
-        ],
-        "base_variable": "hu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ovl40t49",
-        "census_variable": [
-            "B25075_009"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r400t449",
-        "census_variable": [
-            "B25063_010"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "popoochu",
-        "census_variable": [
-            "B25008_002"
-        ],
-        "base_variable": "avghhsooc",
-        "domain": "housing",
-        "source": "",
-        "rounding": 2
-    },
-    {
-        "pff_variable": "btrvvetc",
-        "census_variable": [
-            "DP04_0015"
-        ],
-        "base_variable": "hu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r600t649",
-        "census_variable": [
-            "B25063_014"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r800t899",
-        "census_variable": [
-            "B25063_018"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "gr15kt19k",
-        "census_variable": [
-            "DP04_0130"
-        ],
-        "base_variable": "ochuprnt1",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rochu2",
-        "census_variable": [
-            "DP04_0047"
-        ],
-        "base_variable": "avghhsroc",
-        "domain": "housing",
-        "source": "",
-        "rounding": 2
-    },
-    {
-        "pff_variable": "r1p5t1999",
-        "census_variable": [
-            "B25063_022"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "blt00t09",
-        "census_variable": [
-            "DP04_0019"
-        ],
-        "base_variable": "hu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "grpiu15",
-        "census_variable": [
-            "DP04_0137"
-        ],
-        "base_variable": "ochuprnt2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ov250t299",
-        "census_variable": [
-            "B25075_020"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hu1",
-        "census_variable": [
-            "DP04_0001"
-        ],
-        "base_variable": "hu1",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ochu5",
-        "census_variable": [
-            "DP04_0076"
-        ],
-        "base_variable": "ochu5",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "novhclav",
-        "census_variable": [
-            "DP04_0058"
-        ],
-        "base_variable": "ochu4",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hu5t9u",
-        "census_variable": [
-            "DP04_0011"
-        ],
-        "base_variable": "hu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdrms",
-        "census_variable": [
-            "DP04_0037"
-        ],
-        "base_variable": "median",
-        "domain": "housing",
-        "source": "",
-        "rounding": 1
-    },
-    {
-        "pff_variable": "grpi35pl",
-        "census_variable": [
-            "DP04_0142"
-        ],
-        "base_variable": "ochuprnt2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ovl30t34",
-        "census_variable": [
-            "B25075_007"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "blt10ltr",
-        "census_variable": [
-            "DP04_0017",
-            "DP04_0018"
-        ],
-        "base_variable": "hu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r750t799",
-        "census_variable": [
-            "B25063_017"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ovl50t59",
-        "census_variable": [
-            "B25075_010"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nmsmpntc",
-        "census_variable": [
-            "DP04_0125"
-        ],
-        "base_variable": "nan",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vacsoldno",
-        "census_variable": [
-            "B25004_005"
-        ],
-        "base_variable": "vacsoldno",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rms2",
-        "census_variable": [
-            "DP04_0029"
-        ],
-        "base_variable": "hu4",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "blt60t69",
-        "census_variable": [
-            "DP04_0023"
-        ],
-        "base_variable": "hu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r2kt2499",
-        "census_variable": [
-            "B25063_023"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r700t749",
-        "census_variable": [
-            "B25063_016"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ovl60t69",
-        "census_variable": [
-            "B25075_011"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vachu",
-        "census_variable": [
-            "DP04_0003"
-        ],
-        "base_variable": "hu1",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hunomrtg1",
-        "census_variable": [
-            "DP04_0092"
-        ],
-        "base_variable": "oochu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hovacu",
-        "census_variable": [
-            "DP04_0046",
-            "B25004_005",
-            "B25004_004"
-        ],
-        "base_variable": "hovacrt",
-        "domain": "housing",
-        "source": "",
-        "rounding": 1
-    },
-    {
-        "pff_variable": "r500t549",
-        "census_variable": [
-            "B25063_012"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ochu1",
-        "census_variable": [
-            "DP04_0002"
-        ],
-        "base_variable": "hu1",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hu1ud",
-        "census_variable": [
-            "DP04_0007"
-        ],
-        "base_variable": "hu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nmsmpu10",
-        "census_variable": [
-            "DP04_0118"
-        ],
-        "base_variable": "hunomrtg2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "grpi30t34",
-        "census_variable": [
-            "DP04_0141"
-        ],
-        "base_variable": "ochuprnt2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rntvacu",
-        "census_variable": [
-            "B25004_003",
-            "DP04_0047",
-            "B25004_002"
-        ],
-        "base_variable": "rntvacrt",
-        "domain": "housing",
-        "source": "",
-        "rounding": 1
-    },
-    {
-        "pff_variable": "mv10ltr",
-        "census_variable": [
-            "DP04_0052",
-            "DP04_0051"
-        ],
-        "base_variable": "ochu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r250t299",
-        "census_variable": [
-            "B25063_007"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "huwmrtg",
-        "census_variable": [
-            "DP04_0091"
-        ],
-        "base_variable": "oochu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r900t999",
-        "census_variable": [
-            "B25063_019"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ovl15t19",
-        "census_variable": [
-            "B25075_004"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hu4",
-        "census_variable": [
-            "DP04_0027"
-        ],
-        "base_variable": "hu4",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oochu2",
-        "census_variable": [
-            "DP04_0080"
-        ],
-        "base_variable": "oochu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nmsmp2529",
-        "census_variable": [
-            "DP04_0122"
-        ],
-        "base_variable": "hunomrtg2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r350t399",
-        "census_variable": [
-            "B25063_009"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nmsmp3034",
-        "census_variable": [
-            "DP04_0123"
-        ],
-        "base_variable": "hunomrtg2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rms3",
-        "census_variable": [
-            "DP04_0030"
-        ],
-        "base_variable": "hu4",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r1250t1p5",
-        "census_variable": [
-            "B25063_021"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r3500pl",
-        "census_variable": [
-            "B25063_026"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ov2milpl",
-        "census_variable": [
-            "B25075_027"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vacrnt",
-        "census_variable": [
-            "B25004_002"
-        ],
-        "base_variable": "rntvacrt",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vl1milpl",
-        "census_variable": [
-            "DP04_0088"
-        ],
-        "base_variable": "oochu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r200t249",
-        "census_variable": [
-            "B25063_006"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r1kt1249",
-        "census_variable": [
-            "B25063_020"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ovl90t99",
-        "census_variable": [
-            "B25075_014"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdgr",
-        "census_variable": [
-            "DP04_0134"
-        ],
-        "base_variable": "median",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ov175t199",
-        "census_variable": [
-            "B25075_018"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mv80t89",
-        "census_variable": [
-            "DP04_0055"
-        ],
-        "base_variable": "ochu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ov125t149",
-        "census_variable": [
-            "B25075_016"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vl500t999",
-        "census_variable": [
-            "DP04_0087"
-        ],
-        "base_variable": "oochu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ovl25t29",
-        "census_variable": [
-            "B25075_006"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hovacrt",
-        "census_variable": [
-            "DP04_0004"
-        ],
-        "base_variable": "rate",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rochu1",
-        "census_variable": [
-            "DP04_0047"
-        ],
-        "base_variable": "ochu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ochu3",
-        "census_variable": [
-            "DP04_0050"
-        ],
-        "base_variable": "ochu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vl150t199",
-        "census_variable": [
-            "DP04_0084"
-        ],
-        "base_variable": "oochu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hu10t19u",
-        "census_variable": [
-            "DP04_0012"
-        ],
-        "base_variable": "hu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vl50t99",
-        "census_variable": [
-            "DP04_0082"
-        ],
-        "base_variable": "oochu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nmsmp1014",
-        "census_variable": [
-            "DP04_0119"
-        ],
-        "base_variable": "hunomrtg2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ov400t499",
-        "census_variable": [
-            "B25075_022"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vhcl3plav",
-        "census_variable": [
-            "DP04_0061"
-        ],
-        "base_variable": "ochu4",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "huwmrtgex",
-        "census_variable": [
-            "DP04_0110"
-        ],
-        "base_variable": "huwmrtgex",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ru100",
-        "census_variable": [
-            "B25063_003"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "blt80t89",
-        "census_variable": [
-            "DP04_0021"
-        ],
-        "base_variable": "hu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ochuprnt1",
-        "census_variable": [
-            "DP04_0126"
-        ],
-        "base_variable": "ochuprnt1",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "gr20kt24k",
-        "census_variable": [
-            "DP04_0131"
-        ],
-        "base_variable": "ochuprnt1",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vacsale",
-        "census_variable": [
-            "B25004_004"
-        ],
-        "base_variable": "hovacrt",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "gr25kt29k",
-        "census_variable": [
-            "DP04_0132"
-        ],
-        "base_variable": "ochuprnt1",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r2p5t2999",
-        "census_variable": [
-            "B25063_024"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hu2",
-        "census_variable": [
-            "DP04_0006"
-        ],
-        "base_variable": "hu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vl200t299",
-        "census_variable": [
-            "DP04_0085"
-        ],
-        "base_variable": "oochu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ovl80t89",
-        "census_variable": [
-            "B25075_013"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ovlu10",
-        "census_variable": [
-            "B25075_002"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vl100t149",
-        "census_variable": [
-            "DP04_0083"
-        ],
-        "base_variable": "oochu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ov750t999",
-        "census_variable": [
-            "B25075_024"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vacrntno",
-        "census_variable": [
-            "B25004_003"
-        ],
-        "base_variable": "vacrntno",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r150t199",
-        "census_variable": [
-            "B25063_005"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hu3t4u",
-        "census_variable": [
-            "DP04_0010"
-        ],
-        "base_variable": "hu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "smp25t29",
-        "census_variable": [
-            "DP04_0113"
-        ],
-        "base_variable": "huwmrtgex",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hu20plu",
-        "census_variable": [
-            "DP04_0013"
-        ],
-        "base_variable": "hu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vhcl2av",
-        "census_variable": [
-            "DP04_0060"
-        ],
-        "base_variable": "ochu4",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ov500t749",
-        "census_variable": [
-            "B25075_023"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "gr500t999",
-        "census_variable": [
-            "DP04_0128"
-        ],
-        "base_variable": "ochuprnt1",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nmsmp35pl",
-        "census_variable": [
-            "DP04_0124"
-        ],
-        "base_variable": "hunomrtg2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r3kt3499",
-        "census_variable": [
-            "B25063_025"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ov1t149m",
-        "census_variable": [
-            "B25075_025"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "grpi20t24",
-        "census_variable": [
-            "DP04_0139"
-        ],
-        "base_variable": "ochuprnt2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "smpu20",
-        "census_variable": [
-            "DP04_0111"
-        ],
-        "base_variable": "huwmrtgex",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rms6",
-        "census_variable": [
-            "DP04_0033"
-        ],
-        "base_variable": "hu4",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ochuprnt2",
-        "census_variable": [
-            "DP04_0136"
-        ],
-        "base_variable": "ochuprnt2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "blt90t99",
-        "census_variable": [
-            "DP04_0020"
-        ],
-        "base_variable": "hu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "grpintc",
-        "census_variable": [
-            "DP04_0143"
-        ],
-        "base_variable": "nan",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ochu2",
-        "census_variable": [
-            "DP04_0045"
-        ],
-        "base_variable": "ochu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ov300t399",
-        "census_variable": [
-            "B25075_021"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mobhm",
-        "census_variable": [
-            "DP04_0014"
-        ],
-        "base_variable": "hu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oochu1",
-        "census_variable": [
-            "DP04_0046"
-        ],
-        "base_variable": "ochu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdvl",
-        "census_variable": [
-            "DP04_0089"
-        ],
-        "base_variable": "median",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r300t349",
-        "census_variable": [
-            "B25063_008"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rms1",
-        "census_variable": [
-            "DP04_0028"
-        ],
-        "base_variable": "hu4",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rms4",
-        "census_variable": [
-            "DP04_0031"
-        ],
-        "base_variable": "hu4",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "smp35pl",
-        "census_variable": [
-            "DP04_0115"
-        ],
-        "base_variable": "huwmrtgex",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "grpi25t29",
-        "census_variable": [
-            "DP04_0140"
-        ],
-        "base_variable": "ochuprnt2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ovl20t24",
-        "census_variable": [
-            "B25075_005"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "grnorntpd",
-        "census_variable": [
-            "DP04_0135"
-        ],
-        "base_variable": "nan",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oochu3",
-        "census_variable": [
-            "DP04_0090"
-        ],
-        "base_variable": "oochu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "smp30t34",
-        "census_variable": [
-            "DP04_0114"
-        ],
-        "base_variable": "huwmrtgex",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oochu5",
-        "census_variable": [
-            "B25075_001"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rms9pl",
-        "census_variable": [
-            "DP04_0036"
-        ],
-        "base_variable": "hu4",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "blt70t79",
-        "census_variable": [
-            "DP04_0022"
-        ],
-        "base_variable": "hu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "avghhsroc",
-        "census_variable": [
-            "DP04_0049"
-        ],
-        "base_variable": "mean",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "oochu4",
-        "census_variable": [
-            "DP04_0046"
-        ],
-        "base_variable": "avghhsooc",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ocpr1pl",
-        "census_variable": [
-            "DP04_0078",
-            "DP04_0079"
-        ],
-        "base_variable": "ochu5",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nmsmp1519",
-        "census_variable": [
-            "DP04_0120"
-        ],
-        "base_variable": "hunomrtg2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r650t699",
-        "census_variable": [
-            "B25063_015"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ocpr1p5pl",
-        "census_variable": [
-            "DP04_0079"
-        ],
-        "base_variable": "ochu5",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "smp20t24",
-        "census_variable": [
-            "DP04_0112"
-        ],
-        "base_variable": "huwmrtgex",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ov150t174",
-        "census_variable": [
-            "B25075_017"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "bltbf39",
-        "census_variable": [
-            "DP04_0026"
-        ],
-        "base_variable": "hu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rms5",
-        "census_variable": [
-            "DP04_0032"
-        ],
-        "base_variable": "hu4",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "gru500",
-        "census_variable": [
-            "DP04_0127"
-        ],
-        "base_variable": "ochuprnt1",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "gr1kt14k",
-        "census_variable": [
-            "DP04_0129"
-        ],
-        "base_variable": "ochuprnt1",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mvbf79",
-        "census_variable": [
-            "DP04_0056"
-        ],
-        "base_variable": "ochu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nmsmp2024",
-        "census_variable": [
-            "DP04_0121"
-        ],
-        "base_variable": "hunomrtg2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ovl70t79",
-        "census_variable": [
-            "B25075_012"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ov100t124",
-        "census_variable": [
-            "B25075_015"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ovl10t14",
-        "census_variable": [
-            "B25075_003"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hu2u",
-        "census_variable": [
-            "DP04_0009"
-        ],
-        "base_variable": "hu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ovl35t39",
-        "census_variable": [
-            "B25075_008"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rms7",
-        "census_variable": [
-            "DP04_0034"
-        ],
-        "base_variable": "hu4",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r550t599",
-        "census_variable": [
-            "B25063_013"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ov150t199m",
-        "census_variable": [
-            "B25075_026"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "grpi50pl",
-        "census_variable": [
-            "B25070_010"
-        ],
-        "base_variable": "ochuprnt2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "grpi15t19",
-        "census_variable": [
-            "DP04_0138"
-        ],
-        "base_variable": "ochuprnt2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r100t149",
-        "census_variable": [
-            "B25063_004"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vl300t499",
-        "census_variable": [
-            "DP04_0086"
-        ],
-        "base_variable": "oochu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hunomrtg2",
-        "census_variable": [
-            "DP04_0117"
-        ],
-        "base_variable": "hunomrtg2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ocpr0t1",
-        "census_variable": [
-            "DP04_0077"
-        ],
-        "base_variable": "ochu5",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "gr3kpl",
-        "census_variable": [
-            "DP04_0133"
-        ],
-        "base_variable": "ochuprnt1",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "avghhsooc",
-        "census_variable": [
-            "DP04_0048"
-        ],
-        "base_variable": "mean",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mv90t99",
-        "census_variable": [
-            "DP04_0054"
-        ],
-        "base_variable": "ochu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "vlu50",
-        "census_variable": [
-            "DP04_0081"
-        ],
-        "base_variable": "oochu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "roccshrnt",
-        "census_variable": [
-            "B25063_002"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "poprtochu",
-        "census_variable": [
-            "B25008_003"
-        ],
-        "base_variable": "avghhsroc",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mv00t09",
-        "census_variable": [
-            "DP04_0053"
-        ],
-        "base_variable": "ochu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hu1ua",
-        "census_variable": [
-            "DP04_0008"
-        ],
-        "base_variable": "hu2",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "blt40t49",
-        "census_variable": [
-            "DP04_0025"
-        ],
-        "base_variable": "hu3",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "r450t499",
-        "census_variable": [
-            "B25063_011"
-        ],
-        "base_variable": "mdgr",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "smpntc",
-        "census_variable": [
-            "DP04_0116"
-        ],
-        "base_variable": "nan",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rntvacrt",
-        "census_variable": [
-            "DP04_0005"
-        ],
-        "base_variable": "rate",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "rms8",
-        "census_variable": [
-            "DP04_0035"
-        ],
-        "base_variable": "hu4",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "ov200t249",
-        "census_variable": [
-            "B25075_019"
-        ],
-        "base_variable": "mdvl",
-        "domain": "housing",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop25t29",
-        "census_variable": [
-            "B01001_035",
-            "B01001_011"
-        ],
-        "base_variable": "pop_1",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
         "pff_variable": "f16pl",
         "census_variable": [
             "DP03_0010"
         ],
         "base_variable": "f16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop0t5",
-        "census_variable": [
-            "B01001_027"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvnipop2",
-        "census_variable": [
-            "DP03_0095"
-        ],
-        "base_variable": "cvnipop2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop35t39",
-        "census_variable": [
-            "B01001_013"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nlf1",
@@ -7228,8 +16,8 @@
         ],
         "base_variable": "pop16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mft2p5t5",
@@ -7238,8 +26,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdefftwrk",
@@ -7248,19 +36,8 @@
         ],
         "base_variable": "median",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop67t69",
-        "census_variable": [
-            "B01001_045",
-            "B01001_021"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "inc_cpba",
@@ -7269,8 +46,8 @@
         ],
         "base_variable": "hh2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "wrkr16pl",
@@ -7279,8 +56,8 @@
         ],
         "base_variable": "wrkr16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "prdtrnsmm",
@@ -7289,18 +66,8 @@
         ],
         "base_variable": "cvem16pl2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop80t84",
-        "census_variable": [
-            "B01001_048"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdemftwrk",
@@ -7309,8 +76,8 @@
         ],
         "base_variable": "median",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhhi30t34",
@@ -7319,29 +86,8 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop65t66",
-        "census_variable": [
-            "B01001_044",
-            "B01001_020"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "empbhins",
-        "census_variable": [
-            "DP03_0107"
-        ],
-        "base_variable": "cvlfem",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mft7p5t10",
@@ -7350,8 +96,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fftu2pt5k",
@@ -7360,48 +106,27 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pv175t184",
         "census_variable": [
-            "B17024_035",
+            "B17024_009",
             "B17024_022",
-            "B17024_126",
-            "B17024_061",
-            "B17024_087",
-            "B17024_074",
+            "B17024_035",
             "B17024_048",
+            "B17024_061",
+            "B17024_074",
+            "B17024_087",
             "B17024_100",
             "B17024_113",
-            "B17024_009"
+            "B17024_126"
         ],
         "base_variable": "poppvu2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "empvhins",
-        "census_variable": [
-            "DP03_0106"
-        ],
-        "base_variable": "cvlfem",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop21",
-        "census_variable": [
-            "B01001_009",
-            "B01001_033"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhh",
@@ -7410,28 +135,8 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "whlsale",
-        "census_variable": [
-            "DP03_0036"
-        ],
-        "base_variable": "cvem16pl3",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hi150t199",
-        "census_variable": [
-            "DP03_0060"
-        ],
-        "base_variable": "hh2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mf17p5t20",
@@ -7440,8 +145,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhi150t199",
@@ -7450,8 +155,8 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nfmi45t49",
@@ -7460,8 +165,8 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfami50t59",
@@ -7470,8 +175,8 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "slfemninc",
@@ -7480,18 +185,8 @@
         ],
         "base_variable": "cvem16pl4",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop85pl",
-        "census_variable": [
-            "B01001_049"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ff10t12p5",
@@ -7500,8 +195,8 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mft5t7p5",
@@ -7510,8 +205,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nfmi30t34",
@@ -7520,8 +215,8 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "salesoff",
@@ -7530,8 +225,8 @@
         ],
         "base_variable": "cvem16pl2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "agip15pl",
@@ -7540,8 +235,8 @@
         ],
         "base_variable": "percapinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdnfinc",
@@ -7550,8 +245,8 @@
         ],
         "base_variable": "median",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfi150t199",
@@ -7560,28 +255,8 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "emhins",
-        "census_variable": [
-            "DP03_0105"
-        ],
-        "base_variable": "cvlfem",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hi100t149",
-        "census_variable": [
-            "DP03_0059"
-        ],
-        "base_variable": "hh2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fam2",
@@ -7590,42 +265,21 @@
         ],
         "base_variable": "fam2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop80t84",
-        "census_variable": [
-            "B01001_048",
-            "B01001_024"
-        ],
-        "base_variable": "pop_1",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ern50t55",
         "census_variable": [
-            "B20005_068",
-            "B20005_091",
             "B20005_021",
-            "B20005_044"
+            "B20005_044",
+            "B20005_068",
+            "B20005_091"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "retail",
-        "census_variable": [
-            "DP03_0037"
-        ],
-        "base_variable": "cvem16pl3",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pop_6",
@@ -7634,29 +288,21 @@
         ],
         "base_variable": "percapinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "p65plbwpv",
         "census_variable": [
-            "S1701_C02_010"
+            "B17001_015",
+            "B17001_016",
+            "B17001_029",
+            "B17001_030"
         ],
         "base_variable": "p65plpvu",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop35t39",
-        "census_variable": [
-            "B01001_013",
-            "B01001_037"
-        ],
-        "base_variable": "pop_1",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mntrvtm",
@@ -7665,21 +311,21 @@
         ],
         "base_variable": "mean",
         "domain": "economic",
-        "source": "",
-        "rounding": 1
+        "rounding": 1,
+        "source": ""
     },
     {
         "pff_variable": "ern75t100",
         "census_variable": [
-            "B20005_071",
             "B20005_024",
-            "B20005_094",
-            "B20005_047"
+            "B20005_047",
+            "B20005_071",
+            "B20005_094"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "updfmwrkr",
@@ -7688,18 +334,8 @@
         ],
         "base_variable": "cvem16pl4",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nlfnhins",
-        "census_variable": [
-            "DP03_0118"
-        ],
-        "base_variable": "nlf2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "hh5",
@@ -7708,28 +344,8 @@
         ],
         "base_variable": "mnhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nlf2",
-        "census_variable": [
-            "DP03_0114"
-        ],
-        "base_variable": "nlf2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop75t79",
-        "census_variable": [
-            "B01001_047"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fft40t45",
@@ -7738,37 +354,27 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop50t54",
-        "census_variable": [
-            "B01001_040"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pv200t299",
         "census_variable": [
             "B17024_011",
-            "B17024_063",
-            "B17024_102",
-            "B17024_115",
-            "B17024_037",
             "B17024_024",
-            "B17024_128",
+            "B17024_037",
+            "B17024_050",
+            "B17024_063",
             "B17024_076",
             "B17024_089",
-            "B17024_050"
+            "B17024_102",
+            "B17024_115",
+            "B17024_128"
         ],
         "base_variable": "poppvu2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fft30t35",
@@ -7777,18 +383,29 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pu18bwpv",
         "census_variable": [
-            "S1701_C02_002"
+            "B17001_004",
+            "B17001_005",
+            "B17001_006",
+            "B17001_007",
+            "B17001_008",
+            "B17001_009",
+            "B17001_018",
+            "B17001_019",
+            "B17001_020",
+            "B17001_021",
+            "B17001_022",
+            "B17001_023"
         ],
         "base_variable": "pu18pvu",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "cvlfuem2",
@@ -7797,76 +414,46 @@
         ],
         "base_variable": "cvlf2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pv75t99",
         "census_variable": [
-            "B17024_044",
-            "B17024_018",
-            "B17024_096",
-            "B17024_109",
-            "B17024_122",
             "B17024_005",
+            "B17024_018",
             "B17024_031",
+            "B17024_044",
             "B17024_057",
             "B17024_070",
-            "B17024_083"
+            "B17024_083",
+            "B17024_096",
+            "B17024_109",
+            "B17024_122"
         ],
         "base_variable": "poppvu2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pv150t174",
         "census_variable": [
-            "B17024_034",
-            "B17024_112",
-            "B17024_021",
-            "B17024_060",
-            "B17024_099",
             "B17024_008",
+            "B17024_021",
+            "B17024_034",
+            "B17024_047",
+            "B17024_060",
             "B17024_073",
             "B17024_086",
-            "B17024_125",
-            "B17024_047"
+            "B17024_099",
+            "B17024_112",
+            "B17024_125"
         ],
         "base_variable": "poppvu2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hhi25t34",
-        "census_variable": [
-            "DP03_0055"
-        ],
-        "base_variable": "hh2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hhi35t49",
-        "census_variable": [
-            "DP03_0056"
-        ],
-        "base_variable": "hh2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop50t54",
-        "census_variable": [
-            "B01001_016"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhi100t124",
@@ -7875,81 +462,40 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mnfctrng",
-        "census_variable": [
-            "DP03_0035"
-        ],
-        "base_variable": "cvem16pl3",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop15t19",
-        "census_variable": [
-            "B01001_031",
-            "B01001_030"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hhiu10",
-        "census_variable": [
-            "DP03_0052"
-        ],
-        "base_variable": "hh2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pv185t199",
         "census_variable": [
+            "B17024_010",
+            "B17024_023",
+            "B17024_036",
+            "B17024_049",
+            "B17024_062",
             "B17024_075",
+            "B17024_088",
             "B17024_101",
             "B17024_114",
-            "B17024_062",
-            "B17024_127",
-            "B17024_049",
-            "B17024_088",
-            "B17024_023",
-            "B17024_010",
-            "B17024_036"
+            "B17024_127"
         ],
         "base_variable": "poppvu2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop10t14",
-        "census_variable": [
-            "B01001_005"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ern25t30",
         "census_variable": [
-            "B20005_063",
-            "B20005_086",
             "B20005_016",
-            "B20005_039"
+            "B20005_039",
+            "B20005_063",
+            "B20005_086"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "cvlfuem1",
@@ -7958,48 +504,27 @@
         ],
         "base_variable": "pop16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fami50t74",
-        "census_variable": [
-            "DP03_0081"
-        ],
-        "base_variable": "fam2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pv500pl",
         "census_variable": [
-            "B17024_027",
-            "B17024_079",
-            "B17024_053",
             "B17024_014",
-            "B17024_105",
-            "B17024_131",
-            "B17024_092",
+            "B17024_027",
             "B17024_040",
+            "B17024_053",
+            "B17024_066",
+            "B17024_079",
+            "B17024_092",
+            "B17024_105",
             "B17024_118",
-            "B17024_066"
+            "B17024_131"
         ],
         "base_variable": "poppvu2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop22t24",
-        "census_variable": [
-            "B01001_010",
-            "B01001_034"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fft55t65",
@@ -8008,30 +533,8 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop15t17",
-        "census_variable": [
-            "B01001_006",
-            "B01001_030"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop45t49",
-        "census_variable": [
-            "B01001_015",
-            "B01001_039"
-        ],
-        "base_variable": "pop_1",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "cvlf2",
@@ -8040,19 +543,8 @@
         ],
         "base_variable": "cvlf2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop65t69",
-        "census_variable": [
-            "B01001_021",
-            "B01001_020"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mwrkern",
@@ -8061,61 +553,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fami200pl",
-        "census_variable": [
-            "DP03_0085"
-        ],
-        "base_variable": "fam2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop30t34",
-        "census_variable": [
-            "B01001_036",
-            "B01001_012"
-        ],
-        "base_variable": "pop_1",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop45t49",
-        "census_variable": [
-            "B01001_015",
-            "B01001_039"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fami25t34",
-        "census_variable": [
-            "DP03_0079"
-        ],
-        "base_variable": "fam2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop40t44",
-        "census_variable": [
-            "B01001_014",
-            "B01001_038"
-        ],
-        "base_variable": "pop_1",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nfam2",
@@ -8124,8 +563,8 @@
         ],
         "base_variable": "nfam2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pop16pl",
@@ -8134,29 +573,18 @@
         ],
         "base_variable": "pop16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pbwpv",
         "census_variable": [
-            "S1701_C02_001"
+            "B17001_002"
         ],
         "base_variable": "poppvu1",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop35t39",
-        "census_variable": [
-            "B01001_013",
-            "B01001_037"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 1
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fft5t7p5",
@@ -8165,18 +593,8 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop",
-        "census_variable": [
-            "B01001_001"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhhi40t44",
@@ -8185,32 +603,21 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "e22pt5t25",
         "census_variable": [
             "B20005_015",
-            "B20005_085",
+            "B20005_038",
             "B20005_062",
-            "B20005_038"
+            "B20005_085"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop15t19",
-        "census_variable": [
-            "B01001_006",
-            "B01001_007"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mgbsciart",
@@ -8219,19 +626,8 @@
         ],
         "base_variable": "cvem16pl2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop70t74",
-        "census_variable": [
-            "B01001_022",
-            "B01001_046"
-        ],
-        "base_variable": "pop_1",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fft7p5t10",
@@ -8240,18 +636,8 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop70t74",
-        "census_variable": [
-            "B01001_046"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "cw_wlkd",
@@ -8260,8 +646,8 @@
         ],
         "base_variable": "wrkr16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfami25t29",
@@ -8270,28 +656,8 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop75t79",
-        "census_variable": [
-            "B01001_023"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "othnotpa",
-        "census_variable": [
-            "DP03_0044"
-        ],
-        "base_variable": "cvem16pl3",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mft40t45",
@@ -8300,27 +666,27 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pv125t149",
         "census_variable": [
-            "B17024_033",
-            "B17024_124",
-            "B17024_111",
-            "B17024_098",
-            "B17024_020",
             "B17024_007",
+            "B17024_020",
+            "B17024_033",
             "B17024_046",
-            "B17024_072",
             "B17024_059",
-            "B17024_085"
+            "B17024_072",
+            "B17024_085",
+            "B17024_098",
+            "B17024_111",
+            "B17024_124"
         ],
         "base_variable": "poppvu2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfami40t44",
@@ -8329,8 +695,8 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "aghhinc",
@@ -8339,19 +705,8 @@
         ],
         "base_variable": "mnhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop60t64",
-        "census_variable": [
-            "B01001_042",
-            "B01001_043"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nfmi35t39",
@@ -8360,8 +715,8 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fft50t55",
@@ -8370,8 +725,8 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhhinc",
@@ -8380,18 +735,8 @@
         ],
         "base_variable": "median",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop85pl",
-        "census_variable": [
-            "B01001_025"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nfmi20t24",
@@ -8400,29 +745,19 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "wrkrnothm",
         "census_variable": [
-            "DP03_0024",
-            "DP03_0018"
+            "DP03_0018",
+            "DP03_0024"
         ],
         "base_variable": "mntrvtm",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "info",
-        "census_variable": [
-            "DP03_0039"
-        ],
-        "base_variable": "cvem16pl3",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mft30t35",
@@ -8431,8 +766,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ff12p5t15",
@@ -8441,28 +776,8 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop80t84",
-        "census_variable": [
-            "B01001_024"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop0t5",
-        "census_variable": [
-            "B01001_003"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "cvem16pl1",
@@ -8471,31 +786,21 @@
         ],
         "base_variable": "pop16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "e10t12pt5",
         "census_variable": [
-            "B20005_033",
             "B20005_010",
-            "B20005_080",
-            "B20005_057"
+            "B20005_033",
+            "B20005_057",
+            "B20005_080"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "agffhm",
-        "census_variable": [
-            "DP03_0033"
-        ],
-        "base_variable": "cvem16pl3",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfi125t149",
@@ -8504,8 +809,8 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfaminc",
@@ -8514,8 +819,8 @@
         ],
         "base_variable": "median",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhhi75t99",
@@ -8524,19 +829,8 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop75t79",
-        "census_variable": [
-            "B01001_047",
-            "B01001_023"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fft35t40",
@@ -8545,40 +839,8 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop65t69",
-        "census_variable": [
-            "B01001_044",
-            "B01001_045"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pvhins",
-        "census_variable": [
-            "DP03_0097"
-        ],
-        "base_variable": "cvnipop2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop10t14",
-        "census_variable": [
-            "B01001_005",
-            "B01001_029"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fft75t100",
@@ -8587,8 +849,8 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhhi45t49",
@@ -8597,8 +859,8 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "och6t17",
@@ -8607,8 +869,8 @@
         ],
         "base_variable": "och6t17",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fambwpv",
@@ -8617,90 +879,50 @@
         ],
         "base_variable": "fampvu",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop30t34",
-        "census_variable": [
-            "B01001_036"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pbhins",
-        "census_variable": [
-            "DP03_0098"
-        ],
-        "base_variable": "cvnipop2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "poppvu1",
         "census_variable": [
-            "S1701_C01_001"
+            "B17001_001"
         ],
         "base_variable": "poppvu1",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "edhlthcsa",
-        "census_variable": [
-            "DP03_0042"
-        ],
-        "base_variable": "cvem16pl3",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ern35t40",
         "census_variable": [
-            "B20005_065",
             "B20005_018",
-            "B20005_088",
-            "B20005_041"
+            "B20005_041",
+            "B20005_065",
+            "B20005_088"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvniu18_2",
-        "census_variable": [
-            "DP03_0100"
-        ],
-        "base_variable": "cvniu18_2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pvu50",
         "census_variable": [
+            "B17024_003",
+            "B17024_016",
             "B17024_029",
-            "B17024_094",
+            "B17024_042",
             "B17024_055",
             "B17024_068",
-            "B17024_107",
-            "B17024_042",
             "B17024_081",
-            "B17024_120",
-            "B17024_016",
-            "B17024_003"
+            "B17024_094",
+            "B17024_107",
+            "B17024_120"
         ],
         "base_variable": "poppvu2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ern30t35",
@@ -8712,8 +934,8 @@
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nfmi10t14",
@@ -8722,18 +944,8 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hhi50t74",
-        "census_variable": [
-            "DP03_0057"
-        ],
-        "base_variable": "hh2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ff20t22p5",
@@ -8742,28 +954,8 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hhi10t14",
-        "census_variable": [
-            "DP03_0053"
-        ],
-        "base_variable": "hh2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "famiu10",
-        "census_variable": [
-            "DP03_0076"
-        ],
-        "base_variable": "fam2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "cw_pbtrns",
@@ -8772,31 +964,21 @@
         ],
         "base_variable": "wrkr16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hins",
-        "census_variable": [
-            "DP03_0096"
-        ],
-        "base_variable": "cvnipop2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "e20t22pt5",
         "census_variable": [
-            "B20005_037",
             "B20005_014",
+            "B20005_037",
             "B20005_061",
             "B20005_084"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ff15t17p5",
@@ -8805,30 +987,8 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop5t9",
-        "census_variable": [
-            "B01001_028",
-            "B01001_004"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop60t61",
-        "census_variable": [
-            "B01001_042",
-            "B01001_018"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhhi25t29",
@@ -8837,8 +997,8 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfami75t99",
@@ -8847,8 +1007,8 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "f16plcvlf",
@@ -8857,21 +1017,21 @@
         ],
         "base_variable": "f16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ern45t50",
         "census_variable": [
             "B20005_020",
-            "B20005_067",
             "B20005_043",
+            "B20005_067",
             "B20005_090"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "cw_oth",
@@ -8880,8 +1040,8 @@
         ],
         "base_variable": "wrkr16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhhiu10",
@@ -8890,8 +1050,8 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mftu2pt5k",
@@ -8900,8 +1060,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhi125t149",
@@ -8910,52 +1070,21 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "uem",
-        "census_variable": [
-            "DP03_0109"
-        ],
-        "base_variable": "uem",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "emnhins",
-        "census_variable": [
-            "DP03_0108"
-        ],
-        "base_variable": "cvlfem",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ern2pt5t5",
         "census_variable": [
-            "B20005_054",
             "B20005_007",
-            "B20005_077",
-            "B20005_030"
+            "B20005_030",
+            "B20005_054",
+            "B20005_077"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop25t29",
-        "census_variable": [
-            "B01001_035",
-            "B01001_011"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fft100pl",
@@ -8964,8 +1093,8 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nfi200pl",
@@ -8974,18 +1103,8 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nhins",
-        "census_variable": [
-            "DP03_0099"
-        ],
-        "base_variable": "cvnipop2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "oc6t17plf",
@@ -8994,39 +1113,8 @@
         ],
         "base_variable": "och6t17",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nlfhins",
-        "census_variable": [
-            "DP03_0115"
-        ],
-        "base_variable": "nlf2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop18t19",
-        "census_variable": [
-            "B01001_031",
-            "B01001_007"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop5t9",
-        "census_variable": [
-            "B01001_004"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fft25t30",
@@ -9035,31 +1123,21 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "e12pt5t15",
         "census_variable": [
-            "B20005_081",
             "B20005_011",
+            "B20005_034",
             "B20005_058",
-            "B20005_034"
+            "B20005_081"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hhi15t24",
-        "census_variable": [
-            "DP03_0054"
-        ],
-        "base_variable": "hh2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "f16pllf",
@@ -9068,8 +1146,8 @@
         ],
         "base_variable": "f16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nf100t124",
@@ -9078,8 +1156,8 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "lf",
@@ -9088,31 +1166,21 @@
         ],
         "base_variable": "pop16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ern5t7pt5",
         "census_variable": [
-            "B20005_078",
-            "B20005_055",
             "B20005_008",
-            "B20005_031"
+            "B20005_031",
+            "B20005_055",
+            "B20005_078"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fami75t99",
-        "census_variable": [
-            "DP03_0082"
-        ],
-        "base_variable": "fam2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhhi50t59",
@@ -9121,8 +1189,8 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "gvtwrkr",
@@ -9131,8 +1199,8 @@
         ],
         "base_variable": "cvem16pl4",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhhi10t14",
@@ -9141,8 +1209,8 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfi100t124",
@@ -9151,18 +1219,8 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fi100t149",
-        "census_variable": [
-            "DP03_0083"
-        ],
-        "base_variable": "fam2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mft100pl",
@@ -9171,52 +1229,21 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "e15t17pt5",
         "census_variable": [
-            "B20005_035",
-            "B20005_082",
             "B20005_012",
-            "B20005_059"
+            "B20005_035",
+            "B20005_059",
+            "B20005_082"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop30t34",
-        "census_variable": [
-            "B01001_036",
-            "B01001_012"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop_3",
-        "census_variable": [
-            "B01001_001"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "uempbhins",
-        "census_variable": [
-            "DP03_0112"
-        ],
-        "base_variable": "uem",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "cw_drvaln",
@@ -9225,18 +1252,8 @@
         ],
         "base_variable": "wrkr16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop70t74",
-        "census_variable": [
-            "B01001_022"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "lfarmdf",
@@ -9245,8 +1262,8 @@
         ],
         "base_variable": "pop16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nfmi60t74",
@@ -9255,34 +1272,34 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ern100pl",
         "census_variable": [
-            "B20005_095",
-            "B20005_072",
+            "B20005_025",
             "B20005_048",
-            "B20005_025"
+            "B20005_072",
+            "B20005_095"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ern65t75",
         "census_variable": [
-            "B20005_093",
             "B20005_023",
+            "B20005_046",
             "B20005_070",
-            "B20005_046"
+            "B20005_093"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "inc_sosec",
@@ -9291,8 +1308,8 @@
         ],
         "base_variable": "hh2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "srvc",
@@ -9301,18 +1318,8 @@
         ],
         "base_variable": "cvem16pl2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "prfsmgawm",
-        "census_variable": [
-            "DP03_0041"
-        ],
-        "base_variable": "cvem16pl3",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "inc_snap",
@@ -9321,44 +1328,21 @@
         ],
         "base_variable": "hh2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop85pl",
-        "census_variable": [
-            "B01001_049",
-            "B01001_025"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "e17pt5t20",
         "census_variable": [
             "B20005_013",
             "B20005_036",
-            "B20005_083",
-            "B20005_060"
+            "B20005_060",
+            "B20005_083"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop20t24",
-        "census_variable": [
-            "B01001_009",
-            "B01001_008",
-            "B01001_010"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mnhhinc",
@@ -9367,8 +1351,8 @@
         ],
         "base_variable": "mean",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fft65t75",
@@ -9377,21 +1361,21 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ernu2pt5k",
         "census_variable": [
-            "B20005_053",
-            "B20005_076",
             "B20005_006",
-            "B20005_029"
+            "B20005_029",
+            "B20005_053",
+            "B20005_076"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nfam",
@@ -9400,50 +1384,8 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fami15t24",
-        "census_variable": [
-            "DP03_0078"
-        ],
-        "base_variable": "fam2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop70t74",
-        "census_variable": [
-            "B01001_022",
-            "B01001_046"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop40t44",
-        "census_variable": [
-            "B01001_014",
-            "B01001_038"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "uemnhins",
-        "census_variable": [
-            "DP03_0113"
-        ],
-        "base_variable": "uem",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfamiu10",
@@ -9452,18 +1394,25 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "p65plpvu",
         "census_variable": [
-            "S1701_C01_010"
+            "B17001_015",
+            "B17001_016",
+            "B17001_029",
+            "B17001_030",
+            "B17001_044",
+            "B17001_045",
+            "B17001_058",
+            "B17001_059"
         ],
         "base_variable": "p65plpvu",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nf150t199",
@@ -9472,21 +1421,8 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop65t69",
-        "census_variable": [
-            "B01001_044",
-            "B01001_045",
-            "B01001_021",
-            "B01001_020"
-        ],
-        "base_variable": "pop_1",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mf20t22p5",
@@ -9495,8 +1431,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fwrkern",
@@ -9505,8 +1441,8 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "inc_spsec",
@@ -9515,29 +1451,8 @@
         ],
         "base_variable": "hh2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop55t59",
-        "census_variable": [
-            "B01001_041",
-            "B01001_017"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop45t49",
-        "census_variable": [
-            "B01001_039"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mft45t50",
@@ -9546,27 +1461,27 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pv100t124",
         "census_variable": [
-            "B17024_071",
-            "B17024_123",
-            "B17024_045",
-            "B17024_110",
+            "B17024_006",
+            "B17024_019",
             "B17024_032",
+            "B17024_045",
+            "B17024_058",
+            "B17024_071",
             "B17024_084",
             "B17024_097",
-            "B17024_019",
-            "B17024_006",
-            "B17024_058"
+            "B17024_110",
+            "B17024_123"
         ],
         "base_variable": "poppvu2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhhi20t24",
@@ -9575,8 +1490,8 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "agttm",
@@ -9585,8 +1500,8 @@
         ],
         "base_variable": "mntrvtm",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ochu6",
@@ -9595,60 +1510,40 @@
         ],
         "base_variable": "ochu6",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ern40t45",
         "census_variable": [
-            "B20005_042",
             "B20005_019",
+            "B20005_042",
             "B20005_066",
             "B20005_089"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop45t49",
-        "census_variable": [
-            "B01001_015"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pv400t499",
         "census_variable": [
-            "B17024_078",
-            "B17024_117",
-            "B17024_130",
-            "B17024_026",
-            "B17024_091",
-            "B17024_052",
             "B17024_013",
+            "B17024_026",
+            "B17024_039",
+            "B17024_052",
             "B17024_065",
+            "B17024_078",
+            "B17024_091",
             "B17024_104",
-            "B17024_039"
+            "B17024_117",
+            "B17024_130"
         ],
         "base_variable": "poppvu2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop10t14",
-        "census_variable": [
-            "B01001_029"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "prvwswrkr",
@@ -9657,8 +1552,8 @@
         ],
         "base_variable": "cvem16pl4",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mft75t100",
@@ -9667,28 +1562,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fi150t199",
-        "census_variable": [
-            "DP03_0084"
-        ],
-        "base_variable": "fam2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop5t9",
-        "census_variable": [
-            "B01001_028"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "cvem16pl4",
@@ -9697,19 +1572,8 @@
         ],
         "base_variable": "cvem16pl4",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop50t54",
-        "census_variable": [
-            "B01001_016",
-            "B01001_040"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "hh2",
@@ -9718,8 +1582,8 @@
         ],
         "base_variable": "hh2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "cw_crpld",
@@ -9728,8 +1592,8 @@
         ],
         "base_variable": "wrkr16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mft55t65",
@@ -9738,28 +1602,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "u18nhins",
-        "census_variable": [
-            "DP03_0101"
-        ],
-        "base_variable": "cvniu18_2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fami10t14",
-        "census_variable": [
-            "DP03_0077"
-        ],
-        "base_variable": "fam2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nfmiu10",
@@ -9768,8 +1612,8 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhhi15t19",
@@ -9778,29 +1622,8 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop20",
-        "census_variable": [
-            "B01001_032",
-            "B01001_008"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fire",
-        "census_variable": [
-            "DP03_0040"
-        ],
-        "base_variable": "cvem16pl3",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhhi60t74",
@@ -9809,8 +1632,8 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mft65t75",
@@ -9819,8 +1642,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "percapinc",
@@ -9829,18 +1652,8 @@
         ],
         "base_variable": "mean",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "uempvhins",
-        "census_variable": [
-            "DP03_0111"
-        ],
-        "base_variable": "uem",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mft25t30",
@@ -9849,8 +1662,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfami60t74",
@@ -9859,40 +1672,8 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fami35t49",
-        "census_variable": [
-            "DP03_0080"
-        ],
-        "base_variable": "fam2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop20t24",
-        "census_variable": [
-            "B01001_032",
-            "B01001_034",
-            "B01001_033"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop55t59",
-        "census_variable": [
-            "B01001_017"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fampvu",
@@ -9901,8 +1682,8 @@
         ],
         "base_variable": "fampvu",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "f16plclfe",
@@ -9911,8 +1692,8 @@
         ],
         "base_variable": "f16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfami15t19",
@@ -9921,28 +1702,8 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "constctn",
-        "census_variable": [
-            "DP03_0034"
-        ],
-        "base_variable": "cvem16pl3",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop25t29",
-        "census_variable": [
-            "B01001_011"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfami10t14",
@@ -9951,18 +1712,8 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop25t29",
-        "census_variable": [
-            "B01001_035"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mft35t40",
@@ -9971,18 +1722,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop35t39",
-        "census_variable": [
-            "B01001_037"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfami20t24",
@@ -9991,8 +1732,8 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhhi200pl",
@@ -10001,8 +1742,8 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "poppvu2",
@@ -10011,18 +1752,8 @@
         ],
         "base_variable": "poppvu2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvem16pl3",
-        "census_variable": [
-            "DP03_0032"
-        ],
-        "base_variable": "cvem16pl3",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mf12p5t15",
@@ -10031,19 +1762,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop62t64",
-        "census_variable": [
-            "B01001_019",
-            "B01001_043"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nfmi15t19",
@@ -10052,39 +1772,41 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop50t54",
-        "census_variable": [
-            "B01001_016",
-            "B01001_040"
-        ],
-        "base_variable": "pop_1",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pu18pvu",
         "census_variable": [
-            "S1701_C01_002"
+            "B17001_004",
+            "B17001_005",
+            "B17001_006",
+            "B17001_007",
+            "B17001_008",
+            "B17001_009",
+            "B17001_018",
+            "B17001_019",
+            "B17001_020",
+            "B17001_021",
+            "B17001_022",
+            "B17001_023",
+            "B17001_033",
+            "B17001_034",
+            "B17001_035",
+            "B17001_036",
+            "B17001_0037",
+            "B17001_038",
+            "B17001_047",
+            "B17001_048",
+            "B17001_049",
+            "B17001_050",
+            "B17001_051",
+            "B17001_052"
         ],
         "base_variable": "pu18pvu",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop55t59",
-        "census_variable": [
-            "B01001_041"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nrcnstmnt",
@@ -10093,18 +1815,8 @@
         ],
         "base_variable": "cvem16pl2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvlfem",
-        "census_variable": [
-            "DP03_0104"
-        ],
-        "base_variable": "cvlfem",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ff17p5t20",
@@ -10113,42 +1825,21 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "wrke16pl",
         "census_variable": [
             "B20005_005",
-            "B20005_075",
             "B20005_028",
-            "B20005_052"
+            "B20005_052",
+            "B20005_075"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pop75t79",
-        "census_variable": [
-            "B01001_047",
-            "B01001_023"
-        ],
-        "base_variable": "pop_1",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "artenrafs",
-        "census_variable": [
-            "DP03_0043"
-        ],
-        "base_variable": "cvem16pl3",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mf15t17p5",
@@ -10157,8 +1848,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fft2p5t5",
@@ -10167,18 +1858,8 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "fpop40t44",
-        "census_variable": [
-            "B01001_038"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "cw_wrkdhm",
@@ -10187,48 +1868,8 @@
         ],
         "base_variable": "wrkr16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nlfpbhins",
-        "census_variable": [
-            "DP03_0117"
-        ],
-        "base_variable": "nlf2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "uemhins",
-        "census_variable": [
-            "DP03_0110"
-        ],
-        "base_variable": "uem",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "trwhut",
-        "census_variable": [
-            "DP03_0038"
-        ],
-        "base_variable": "cvem16pl3",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cni1864_2",
-        "census_variable": [
-            "DP03_0102"
-        ],
-        "base_variable": "nan",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdhhi35t39",
@@ -10237,19 +1878,8 @@
         ],
         "base_variable": "mdhhinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop80t84",
-        "census_variable": [
-            "B01001_048",
-            "B01001_024"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mf22p5t25",
@@ -10258,8 +1888,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nfmi50t59",
@@ -10268,38 +1898,8 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "nlfpvhins",
-        "census_variable": [
-            "DP03_0116"
-        ],
-        "base_variable": "nlf2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hhi200pl",
-        "census_variable": [
-            "DP03_0061"
-        ],
-        "base_variable": "hh2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "hhi75t99",
-        "census_variable": [
-            "DP03_0058"
-        ],
-        "base_variable": "hh2",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mf10t12p5",
@@ -10308,8 +1908,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "cvem16pl2",
@@ -10318,27 +1918,27 @@
         ],
         "base_variable": "cvem16pl2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pv300t399",
         "census_variable": [
-            "B17024_077",
-            "B17024_103",
-            "B17024_025",
-            "B17024_116",
-            "B17024_064",
             "B17024_012",
-            "B17024_090",
+            "B17024_025",
+            "B17024_038",
             "B17024_051",
-            "B17024_129",
-            "B17024_038"
+            "B17024_064",
+            "B17024_077",
+            "B17024_090",
+            "B17024_103",
+            "B17024_116",
+            "B17024_129"
         ],
         "base_variable": "poppvu2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "fft45t50",
@@ -10347,19 +1947,8 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mdpop0t4",
-        "census_variable": [
-            "B01001_027",
-            "B01001_003"
-        ],
-        "base_variable": "mdage",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nf125t149",
@@ -10368,8 +1957,8 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ochu6plf",
@@ -10378,18 +1967,8 @@
         ],
         "base_variable": "ochu6",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "cvlf18t64",
-        "census_variable": [
-            "DP03_0103"
-        ],
-        "base_variable": "nan",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mft50t55",
@@ -10398,29 +1977,8 @@
         ],
         "base_variable": "mdemftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop60t64",
-        "census_variable": [
-            "B01001_019",
-            "B01001_018"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop30t34",
-        "census_variable": [
-            "B01001_012"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nfmi75t99",
@@ -10429,27 +1987,27 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "pv50t74",
         "census_variable": [
-            "B17024_108",
             "B17024_004",
-            "B17024_082",
-            "B17024_069",
             "B17024_017",
             "B17024_030",
             "B17024_043",
-            "B17024_121",
+            "B17024_056",
+            "B17024_069",
+            "B17024_082",
             "B17024_095",
-            "B17024_056"
+            "B17024_108",
+            "B17024_121"
         ],
         "base_variable": "poppvu2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdewrk",
@@ -10458,18 +2016,8 @@
         ],
         "base_variable": "median",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "mpop40t44",
-        "census_variable": [
-            "B01001_014"
-        ],
-        "base_variable": "pop",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfam",
@@ -10478,8 +2026,8 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfami30t34",
@@ -10488,8 +2036,8 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nfmi40t44",
@@ -10498,8 +2046,8 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ff22p5t25",
@@ -10508,8 +2056,8 @@
         ],
         "base_variable": "mdefftwrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "inc_rtrmt",
@@ -10518,21 +2066,21 @@
         ],
         "base_variable": "hh2",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "e7pt5t10",
         "census_variable": [
             "B20005_009",
-            "B20005_079",
             "B20005_032",
-            "B20005_056"
+            "B20005_056",
+            "B20005_079"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "cvlf1",
@@ -10541,8 +2089,8 @@
         ],
         "base_variable": "pop16pl",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfami35t39",
@@ -10551,8 +2099,8 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfami45t49",
@@ -10561,31 +2109,21 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "ern55t65",
         "census_variable": [
             "B20005_022",
-            "B20005_092",
             "B20005_045",
-            "B20005_069"
+            "B20005_069",
+            "B20005_092"
         ],
         "base_variable": "mdewrk",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
-    },
-    {
-        "pff_variable": "pubadmin",
-        "census_variable": [
-            "DP03_0045"
-        ],
-        "base_variable": "cvem16pl3",
-        "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "nfmi25t29",
@@ -10594,8 +2132,8 @@
         ],
         "base_variable": "mdnfinc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
     },
     {
         "pff_variable": "mdfami200pl",
@@ -10604,7 +2142,6025 @@
         ],
         "base_variable": "mdfaminc",
         "domain": "economic",
-        "source": "",
-        "rounding": 0
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "vhcl1av",
+        "census_variable": [
+            "DP04_0058"
+        ],
+        "base_variable": "ochu4",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ochu4",
+        "census_variable": [
+            "DP04_0056"
+        ],
+        "base_variable": "ochu4",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ovl40t49",
+        "census_variable": [
+            "B25075_009"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r400t449",
+        "census_variable": [
+            "B25063_010"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "popoochu",
+        "census_variable": [
+            "B25008_002"
+        ],
+        "base_variable": "avghhsooc",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "btrvvetc",
+        "census_variable": [
+            "DP04_0015"
+        ],
+        "base_variable": "hu2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r600t649",
+        "census_variable": [
+            "B25063_014"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r800t899",
+        "census_variable": [
+            "B25063_018"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rochu2",
+        "census_variable": [
+            "DP04_0046"
+        ],
+        "base_variable": "avghhsroc",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r1p5t1999",
+        "census_variable": [
+            "B25063_022"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "grpiu15",
+        "census_variable": [
+            "DP04_0135"
+        ],
+        "base_variable": "ochuprnt2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ov250t299",
+        "census_variable": [
+            "B25075_020"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hu1",
+        "census_variable": [
+            "DP04_0001"
+        ],
+        "base_variable": "hu1",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ochu5",
+        "census_variable": [
+            "DP04_0075"
+        ],
+        "base_variable": "ochu5",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "novhclav",
+        "census_variable": [
+            "DP04_0057"
+        ],
+        "base_variable": "ochu4",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hu5t9u",
+        "census_variable": [
+            "DP04_0011"
+        ],
+        "base_variable": "hu2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdrms",
+        "census_variable": [
+            "DP04_0036"
+        ],
+        "base_variable": "median",
+        "domain": "housing",
+        "rounding": 1,
+        "source": ""
+    },
+    {
+        "pff_variable": "grpi35pl",
+        "census_variable": [
+            "DP04_0140"
+        ],
+        "base_variable": "ochuprnt2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ovl30t34",
+        "census_variable": [
+            "B25075_007"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r750t799",
+        "census_variable": [
+            "B25063_017"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ovl50t59",
+        "census_variable": [
+            "B25075_010"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nmsmpntc",
+        "census_variable": [
+            "DP04_0123"
+        ],
+        "base_variable": NaN,
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "vacsoldno",
+        "census_variable": [
+            "B25004_005"
+        ],
+        "base_variable": "vacsoldno",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rms2",
+        "census_variable": [
+            "DP04_0028"
+        ],
+        "base_variable": "hu4",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r700t749",
+        "census_variable": [
+            "B25063_016"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ovl60t69",
+        "census_variable": [
+            "B25075_011"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "vachu",
+        "census_variable": [
+            "DP04_0003"
+        ],
+        "base_variable": "hu1",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hunomrtg1",
+        "census_variable": [
+            "DP04_0091"
+        ],
+        "base_variable": "oochu3",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hovacu",
+        "census_variable": [
+            "B25004_004",
+            "B25004_005",
+            "DP04_0045"
+        ],
+        "base_variable": "hovacrt",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r500t549",
+        "census_variable": [
+            "B25063_012"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ochu1",
+        "census_variable": [
+            "DP04_0002"
+        ],
+        "base_variable": "hu1",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hu1ud",
+        "census_variable": [
+            "DP04_0007"
+        ],
+        "base_variable": "hu2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nmsmpu10",
+        "census_variable": [
+            "DP04_0116"
+        ],
+        "base_variable": "hunomrtg2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "grpi30t34",
+        "census_variable": [
+            "DP04_0139"
+        ],
+        "base_variable": "ochuprnt2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rntvacu",
+        "census_variable": [
+            "B25004_002",
+            "B25004_003",
+            "DP04_0046"
+        ],
+        "base_variable": "rntvacrt",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r250t299",
+        "census_variable": [
+            "B25063_007"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "huwmrtg",
+        "census_variable": [
+            "DP04_0090"
+        ],
+        "base_variable": "oochu3",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r900t999",
+        "census_variable": [
+            "B25063_019"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ovl15t19",
+        "census_variable": [
+            "B25075_004"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hu4",
+        "census_variable": [
+            "DP04_0026"
+        ],
+        "base_variable": "hu4",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "oochu2",
+        "census_variable": [
+            "DP04_0079"
+        ],
+        "base_variable": "oochu2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nmsmp2529",
+        "census_variable": [
+            "DP04_0120"
+        ],
+        "base_variable": "hunomrtg2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r350t399",
+        "census_variable": [
+            "B25063_009"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nmsmp3034",
+        "census_variable": [
+            "DP04_0121"
+        ],
+        "base_variable": "hunomrtg2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rms3",
+        "census_variable": [
+            "DP04_0029"
+        ],
+        "base_variable": "hu4",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r1250t1p5",
+        "census_variable": [
+            "B25063_021"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "vacrnt",
+        "census_variable": [
+            "B25004_002"
+        ],
+        "base_variable": "rntvacrt",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r200t249",
+        "census_variable": [
+            "B25063_006"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r1kt1249",
+        "census_variable": [
+            "B25063_020"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ovl90t99",
+        "census_variable": [
+            "B25075_014"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdgr",
+        "census_variable": [
+            "DP04_0132"
+        ],
+        "base_variable": "median",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ov175t199",
+        "census_variable": [
+            "B25075_018"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ov125t149",
+        "census_variable": [
+            "B25075_016"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ovl25t29",
+        "census_variable": [
+            "B25075_006"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hovacrt",
+        "census_variable": [
+            "DP04_0004"
+        ],
+        "base_variable": "rate",
+        "domain": "housing",
+        "rounding": 1,
+        "source": ""
+    },
+    {
+        "pff_variable": "rochu1",
+        "census_variable": [
+            "DP04_0046"
+        ],
+        "base_variable": "ochu2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hu10t19u",
+        "census_variable": [
+            "DP04_0012"
+        ],
+        "base_variable": "hu2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nmsmp1014",
+        "census_variable": [
+            "DP04_0117"
+        ],
+        "base_variable": "hunomrtg2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ov400t499",
+        "census_variable": [
+            "B25075_022"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "vhcl3plav",
+        "census_variable": [
+            "DP04_0060"
+        ],
+        "base_variable": "ochu4",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "huwmrtgex",
+        "census_variable": [
+            "DP04_0108"
+        ],
+        "base_variable": "huwmrtgex",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ru100",
+        "census_variable": [
+            "B25063_003"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "vacsale",
+        "census_variable": [
+            "B25004_004"
+        ],
+        "base_variable": "hovacrt",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hu2",
+        "census_variable": [
+            "DP04_0006"
+        ],
+        "base_variable": "hu2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ovl80t89",
+        "census_variable": [
+            "B25075_013"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ovlu10",
+        "census_variable": [
+            "B25075_002"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ov750t999",
+        "census_variable": [
+            "B25075_024"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "vacrntno",
+        "census_variable": [
+            "B25004_003"
+        ],
+        "base_variable": "vacrntno",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r150t199",
+        "census_variable": [
+            "B25063_005"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hu3t4u",
+        "census_variable": [
+            "DP04_0010"
+        ],
+        "base_variable": "hu2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "smp25t29",
+        "census_variable": [
+            "DP04_0111"
+        ],
+        "base_variable": "huwmrtgex",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hu20plu",
+        "census_variable": [
+            "DP04_0013"
+        ],
+        "base_variable": "hu2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "vhcl2av",
+        "census_variable": [
+            "DP04_0059"
+        ],
+        "base_variable": "ochu4",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ov500t749",
+        "census_variable": [
+            "B25075_023"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nmsmp35pl",
+        "census_variable": [
+            "DP04_0122"
+        ],
+        "base_variable": "hunomrtg2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "grpi20t24",
+        "census_variable": [
+            "DP04_0137"
+        ],
+        "base_variable": "ochuprnt2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "smpu20",
+        "census_variable": [
+            "DP04_0109"
+        ],
+        "base_variable": "huwmrtgex",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rms6",
+        "census_variable": [
+            "DP04_0032"
+        ],
+        "base_variable": "hu4",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ochuprnt2",
+        "census_variable": [
+            "DP04_0134"
+        ],
+        "base_variable": "ochuprnt2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "grpintc",
+        "census_variable": [
+            "DP04_0141"
+        ],
+        "base_variable": NaN,
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ochu2",
+        "census_variable": [
+            "DP04_0044"
+        ],
+        "base_variable": "ochu2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ov300t399",
+        "census_variable": [
+            "B25075_021"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mobhm",
+        "census_variable": [
+            "DP04_0014"
+        ],
+        "base_variable": "hu2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "oochu1",
+        "census_variable": [
+            "DP04_0045"
+        ],
+        "base_variable": "ochu2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdvl",
+        "census_variable": [
+            "DP04_0088"
+        ],
+        "base_variable": "median",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r300t349",
+        "census_variable": [
+            "B25063_008"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rms1",
+        "census_variable": [
+            "DP04_0027"
+        ],
+        "base_variable": "hu4",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rms4",
+        "census_variable": [
+            "DP04_0030"
+        ],
+        "base_variable": "hu4",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "smp35pl",
+        "census_variable": [
+            "DP04_0113"
+        ],
+        "base_variable": "huwmrtgex",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "grpi25t29",
+        "census_variable": [
+            "DP04_0138"
+        ],
+        "base_variable": "ochuprnt2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ovl20t24",
+        "census_variable": [
+            "B25075_005"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "oochu3",
+        "census_variable": [
+            "DP04_0089"
+        ],
+        "base_variable": "oochu3",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "smp30t34",
+        "census_variable": [
+            "DP04_0112"
+        ],
+        "base_variable": "huwmrtgex",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "oochu5",
+        "census_variable": [
+            "B25075_001"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rms9pl",
+        "census_variable": [
+            "DP04_0035"
+        ],
+        "base_variable": "hu4",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "avghhsroc",
+        "census_variable": [
+            "DP04_0048"
+        ],
+        "base_variable": "mean",
+        "domain": "housing",
+        "rounding": 2,
+        "source": ""
+    },
+    {
+        "pff_variable": "oochu4",
+        "census_variable": [
+            "DP04_0045"
+        ],
+        "base_variable": "avghhsooc",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ocpr1pl",
+        "census_variable": [
+            "DP04_0077",
+            "DP04_0078"
+        ],
+        "base_variable": "ochu5",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nmsmp1519",
+        "census_variable": [
+            "DP04_0118"
+        ],
+        "base_variable": "hunomrtg2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r650t699",
+        "census_variable": [
+            "B25063_015"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ocpr1p5pl",
+        "census_variable": [
+            "DP04_0078"
+        ],
+        "base_variable": "ochu5",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "smp20t24",
+        "census_variable": [
+            "DP04_0110"
+        ],
+        "base_variable": "huwmrtgex",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ov150t174",
+        "census_variable": [
+            "B25075_017"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rms5",
+        "census_variable": [
+            "DP04_0031"
+        ],
+        "base_variable": "hu4",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nmsmp2024",
+        "census_variable": [
+            "DP04_0119"
+        ],
+        "base_variable": "hunomrtg2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ovl70t79",
+        "census_variable": [
+            "B25075_012"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ov100t124",
+        "census_variable": [
+            "B25075_015"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ovl10t14",
+        "census_variable": [
+            "B25075_003"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hu2u",
+        "census_variable": [
+            "DP04_0009"
+        ],
+        "base_variable": "hu2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ovl35t39",
+        "census_variable": [
+            "B25075_008"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rms7",
+        "census_variable": [
+            "DP04_0033"
+        ],
+        "base_variable": "hu4",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r550t599",
+        "census_variable": [
+            "B25063_013"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "grpi50pl",
+        "census_variable": [
+            "B25070_010"
+        ],
+        "base_variable": "ochuprnt2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "grpi15t19",
+        "census_variable": [
+            "DP04_0136"
+        ],
+        "base_variable": "ochuprnt2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r100t149",
+        "census_variable": [
+            "B25063_004"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hunomrtg2",
+        "census_variable": [
+            "DP04_0115"
+        ],
+        "base_variable": "hunomrtg2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ocpr0t1",
+        "census_variable": [
+            "DP04_0076"
+        ],
+        "base_variable": "ochu5",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "avghhsooc",
+        "census_variable": [
+            "DP04_0047"
+        ],
+        "base_variable": "mean",
+        "domain": "housing",
+        "rounding": 2,
+        "source": ""
+    },
+    {
+        "pff_variable": "roccshrnt",
+        "census_variable": [
+            "B25063_002"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "poprtochu",
+        "census_variable": [
+            "B25008_003"
+        ],
+        "base_variable": "avghhsroc",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hu1ua",
+        "census_variable": [
+            "DP04_0008"
+        ],
+        "base_variable": "hu2",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r450t499",
+        "census_variable": [
+            "B25063_011"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "smpntc",
+        "census_variable": [
+            "DP04_0114"
+        ],
+        "base_variable": NaN,
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rntvacrt",
+        "census_variable": [
+            "DP04_0005"
+        ],
+        "base_variable": "rate",
+        "domain": "housing",
+        "rounding": 1,
+        "source": ""
+    },
+    {
+        "pff_variable": "rms8",
+        "census_variable": [
+            "DP04_0034"
+        ],
+        "base_variable": "hu4",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ov200t249",
+        "census_variable": [
+            "B25075_019"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ea_grdpfd",
+        "census_variable": [
+            "DP02_0065"
+        ],
+        "base_variable": "ea_p25pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "seasia",
+        "census_variable": [
+            "B05006_067"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "oweur",
+        "census_variable": [
+            "B05006_020"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "vietnam",
+        "census_variable": [
+            "B05006_076"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ms_fnvmrd",
+        "census_variable": [
+            "DP02_0031"
+        ],
+        "base_variable": "ms_f15pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nigeria",
+        "census_variable": [
+            "B05006_112"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "neurpn",
+        "census_variable": [
+            "B04006_058"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "alsatn",
+        "census_variable": [
+            "B04006_004"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "oausnzsbr",
+        "census_variable": [
+            "B05006_119"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ea_hscgrd",
+        "census_variable": [
+            "DP02_0061"
+        ],
+        "base_variable": "ea_p25pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nthrlds",
+        "census_variable": [
+            "B05006_018"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "oseasia",
+        "census_variable": [
+            "B05006_077"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fiji",
+        "census_variable": [
+            "B05006_120"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ghanaian",
+        "census_variable": [
+            "B04006_076"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "croatia",
+        "census_variable": [
+            "B05006_031"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "european",
+        "census_variable": [
+            "B04006_038"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "malaysia",
+        "census_variable": [
+            "B05006_071"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "dhdfcntnyc",
+        "census_variable": [
+            "B07204_006"
+        ],
+        "base_variable": "dfhs2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "lthian",
+        "census_variable": [
+            "B04006_053"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "lthuania",
+        "census_variable": [
+            "B05006_035"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "india",
+        "census_variable": [
+            "B05006_059"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "osthrnafr",
+        "census_variable": [
+            "B05006_107"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "jrdnian",
+        "census_variable": [
+            "B04006_009"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "israeli",
+        "census_variable": [
+            "B04006_050"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "egypt",
+        "census_variable": [
+            "B05006_101"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ms_fmrdsp",
+        "census_variable": [
+            "DP02_0032"
+        ],
+        "base_variable": "ms_f15pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "english",
+        "census_variable": [
+            "B04006_036"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rshp_sp",
+        "census_variable": [
+            "DP02_0019"
+        ],
+        "base_variable": "hhpop",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ethpian",
+        "census_variable": [
+            "B04006_075"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "cvvet18pl",
+        "census_variable": [
+            "DP02_0069"
+        ],
+        "base_variable": "cvpop18pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "liberian",
+        "census_variable": [
+            "B04006_078"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "smhs",
+        "census_variable": [
+            "DP02_0079"
+        ],
+        "base_variable": "pop1pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "german",
+        "census_variable": [
+            "B04006_042"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "oeafr",
+        "census_variable": [
+            "B05006_096"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ms_fsp",
+        "census_variable": [
+            "DP02_0033"
+        ],
+        "base_variable": "ms_f15pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "oseur",
+        "census_variable": [
+            "B05006_026"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "zmbwean",
+        "census_variable": [
+            "B04006_086"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "syria",
+        "census_variable": [
+            "B05006_085"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "sudanese",
+        "census_variable": [
+            "B04006_084"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "somali",
+        "census_variable": [
+            "B04006_082"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "morocco",
+        "census_variable": [
+            "B05006_102"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ntvus",
+        "census_variable": [
+            "DP02_0088"
+        ],
+        "base_variable": "pop_4",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "sierral",
+        "census_variable": [
+            "B05006_113"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "osubsafr",
+        "census_variable": [
+            "B04006_088"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "oneur",
+        "census_variable": [
+            "B05006_012"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "lam",
+        "census_variable": [
+            "B05006_123"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "onam",
+        "census_variable": [
+            "B05006_161"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ms_mnvmrd",
+        "census_variable": [
+            "DP02_0025"
+        ],
+        "base_variable": "ms_m15pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "bulgaria",
+        "census_variable": [
+            "B05006_030"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "colombia",
+        "census_variable": [
+            "B05006_152"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "austrlia",
+        "census_variable": [
+            "B05006_118"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ukraine",
+        "census_variable": [
+            "B05006_041"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "avgfmsz",
+        "census_variable": [
+            "DP02_0016"
+        ],
+        "base_variable": "mean",
+        "domain": "social",
+        "rounding": 2,
+        "source": ""
+    },
+    {
+        "pff_variable": "ms_msp",
+        "census_variable": [
+            "DP02_0027"
+        ],
+        "base_variable": "ms_m15pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop_4",
+        "census_variable": [
+            "DP02_0086"
+        ],
+        "base_variable": "pop_4",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nzealnd",
+        "census_variable": [
+            "B04006_057"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "czechslv",
+        "census_variable": [
+            "B04006_032"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "burma",
+        "census_variable": [
+            "B05006_072"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "thailand",
+        "census_variable": [
+            "B05006_075"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "belizean",
+        "census_variable": [
+            "B04006_097"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "unclsnr",
+        "census_variable": [
+            "B04006_109"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "eritrea",
+        "census_variable": [
+            "B05006_093"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "se_g1t8",
+        "census_variable": [
+            "DP02_0055"
+        ],
+        "base_variable": "pop3plen",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "croatian",
+        "census_variable": [
+            "B04006_029"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "windsub",
+        "census_variable": [
+            "B04006_105"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "afghan",
+        "census_variable": [
+            "B05006_057"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "greece",
+        "census_variable": [
+            "B05006_022"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "cam",
+        "census_variable": [
+            "B05006_137"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "cstarica",
+        "census_variable": [
+            "B05006_140"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rshp_ssup",
+        "census_variable": [
+            "B11009_003",
+            "B11009_005"
+        ],
+        "base_variable": "hhpop",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fbntlzd",
+        "census_variable": [
+            "DP02_0094"
+        ],
+        "base_variable": "fb3",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ms_f15pl",
+        "census_variable": [
+            "DP02_0030"
+        ],
+        "base_variable": "ms_f15pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "frcandian",
+        "census_variable": [
+            "B04006_041"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "jordan",
+        "census_variable": [
+            "B05006_081"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "slovak",
+        "census_variable": [
+            "B04006_070"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "jamaica",
+        "census_variable": [
+            "B05006_132"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "oeeur",
+        "census_variable": [
+            "B05006_045"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ea_ascd",
+        "census_variable": [
+            "DP02_0063"
+        ],
+        "base_variable": "ea_p25pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "portgese",
+        "census_variable": [
+            "B04006_062"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "dchwind",
+        "census_variable": [
+            "B04006_100"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "seur",
+        "census_variable": [
+            "B05006_021"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "wafr",
+        "census_variable": [
+            "B05006_108"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ntv",
+        "census_variable": [
+            "DP02_0087"
+        ],
+        "base_variable": "pop_4",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "germany",
+        "census_variable": [
+            "B05006_017"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "belarus",
+        "census_variable": [
+            "B05006_029"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "austrln",
+        "census_variable": [
+            "B04006_018"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hh1pl65pl",
+        "census_variable": [
+            "DP02_0014"
+        ],
+        "base_variable": "hh1",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "belgium",
+        "census_variable": [
+            "B05006_015"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "asianec",
+        "census_variable": [
+            "B05006_090"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "taiwan",
+        "census_variable": [
+            "B05006_052"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "uknoengsc",
+        "census_variable": [
+            "B05006_005"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mafr",
+        "census_variable": [
+            "B05006_97"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "bahamas",
+        "census_variable": [
+            "B05006_125"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "finnish",
+        "census_variable": [
+            "B04006_039"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "oscasia",
+        "census_variable": [
+            "B05006_066"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "elslvdr",
+        "census_variable": [
+            "B05006_141"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "tandtob",
+        "census_variable": [
+            "B04006_103"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "untdkgdm",
+        "census_variable": [
+            "B05006_004"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "belize",
+        "census_variable": [
+            "B05006_139"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "portugal",
+        "census_variable": [
+            "B05006_024"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "sudan",
+        "census_variable": [
+            "B05006_103"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "serbian",
+        "census_variable": [
+            "B04006_068"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fb1",
+        "census_variable": [
+            "DP02_0092"
+        ],
+        "base_variable": "pop_4",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "avghhsz",
+        "census_variable": [
+            "DP02_0015"
+        ],
+        "base_variable": "mean",
+        "domain": "social",
+        "rounding": 2,
+        "source": ""
+    },
+    {
+        "pff_variable": "ntvprusab",
+        "census_variable": [
+            "DP02_0091"
+        ],
+        "base_variable": "pop_4",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "cvrdean",
+        "census_variable": [
+            "B04006_074"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "bulgrian",
+        "census_variable": [
+            "B04006_024"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rshp_nrup",
+        "census_variable": [
+            "DP02_0023"
+        ],
+        "base_variable": "hhpop",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "owasia",
+        "census_variable": [
+            "B05006_089"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "abroad",
+        "census_variable": [
+            "DP02_0085"
+        ],
+        "base_variable": "dfhs2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ecuador",
+        "census_variable": [
+            "B05006_153"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "luxmbgr",
+        "census_variable": [
+            "B04006_054"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "usvrgis",
+        "census_variable": [
+            "B04006_104"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "cypriot",
+        "census_variable": [
+            "B04006_030"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "eng",
+        "census_variable": [
+            "B05006_006"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "sctchirsh",
+        "census_variable": [
+            "B04006_066"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "sngapore",
+        "census_variable": [
+            "B05006_074"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "svtunion",
+        "census_variable": [
+            "B04006_072"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "asyrchlds",
+        "census_variable": [
+            "B04006_017"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "grenada",
+        "census_variable": [
+            "B05006_130"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rshp_ch",
+        "census_variable": [
+            "DP02_0020"
+        ],
+        "base_variable": "hhpop",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "brzlian",
+        "census_variable": [
+            "B04006_022"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "armenia",
+        "census_variable": [
+            "B05006_088"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "egyptn",
+        "census_variable": [
+            "B04006_007"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "yugoslv",
+        "census_variable": [
+            "B04006_107"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "irish",
+        "census_variable": [
+            "B04006_049"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "dfhsdfcnt",
+        "census_variable": [
+            "DP02_0082"
+        ],
+        "base_variable": "dfhs2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "czech",
+        "census_variable": [
+            "B04006_031"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ghana",
+        "census_variable": [
+            "B05006_110"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "japan",
+        "census_variable": [
+            "B05006_053"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "eeur",
+        "census_variable": [
+            "B05006_027"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "brtwind",
+        "census_variable": [
+            "B04006_099"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ea_sclgnd",
+        "census_variable": [
+            "DP02_0062"
+        ],
+        "base_variable": "ea_p25pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "brbdian",
+        "census_variable": [
+            "B04006_096"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "oeasia",
+        "census_variable": [
+            "B05006_055"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "laos",
+        "census_variable": [
+            "B05006_070"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nicargua",
+        "census_variable": [
+            "B05006_144"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "dfhs2",
+        "census_variable": [
+            "B07204_003",
+            "B07204_016"
+        ],
+        "base_variable": "dfhs2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "norway",
+        "census_variable": [
+            "B05006_0010"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "greek",
+        "census_variable": [
+            "B04006_044"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "poland",
+        "census_variable": [
+            "B05006_038"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "albania",
+        "census_variable": [
+            "B05006_028"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ocam",
+        "census_variable": [
+            "B05006_146"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "bngldsh",
+        "census_variable": [
+            "B05006_058"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ocnianec",
+        "census_variable": [
+            "B05006_121"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "domrep",
+        "census_variable": [
+            "B05006_129"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ms_fwd",
+        "census_variable": [
+            "DP02_0034"
+        ],
+        "base_variable": "ms_f15pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "onafr",
+        "census_variable": [
+            "B05006_104"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "sleonean",
+        "census_variable": [
+            "B04006_081"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "romanian",
+        "census_variable": [
+            "B04006_063"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "brazil",
+        "census_variable": [
+            "B05006_150"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nepal",
+        "census_variable": [
+            "B05006_062"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rshp_nr",
+        "census_variable": [
+            "DP02_0022"
+        ],
+        "base_variable": "hhpop",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "alb",
+        "census_variable": [
+            "B04006_003"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hh1",
+        "census_variable": [
+            "DP02_0001"
+        ],
+        "base_variable": "hh1",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hungary",
+        "census_variable": [
+            "B05006_033"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "amercn",
+        "census_variable": [
+            "B04006_005"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "caboverd",
+        "census_variable": [
+            "B05006_109"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "honduras",
+        "census_variable": [
+            "B05006_143"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "macdnian",
+        "census_variable": [
+            "B04006_055"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "oarab",
+        "census_variable": [
+            "B04006_015"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "germrus",
+        "census_variable": [
+            "B04006_043"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ea_p25pl",
+        "census_variable": [
+            "DP02_0058"
+        ],
+        "base_variable": "ea_p25pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "windies",
+        "census_variable": [
+            "B05006_135"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "weur",
+        "census_variable": [
+            "B05006_013"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "gplgcu18",
+        "census_variable": [
+            "DP02_0043"
+        ],
+        "base_variable": "gplgcu18",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "owafr",
+        "census_variable": [
+            "B05006_114"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "polish",
+        "census_variable": [
+            "B04006_061"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "eeurpn",
+        "census_variable": [
+            "B04006_035"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "romania",
+        "census_variable": [
+            "B05006_039"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ea_bchdh",
+        "census_variable": [
+            "DP02_0064",
+            "DP02_0065"
+        ],
+        "base_variable": "ea_p25pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "cameroon",
+        "census_variable": [
+            "B05006_98"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "dfhs1",
+        "census_variable": [
+            "B07204_003",
+            "B07204_016"
+        ],
+        "base_variable": "pop1pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "belgian",
+        "census_variable": [
+            "B04006_021"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fbnotczn",
+        "census_variable": [
+            "DP02_0095"
+        ],
+        "base_variable": "fb3",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "arabsub",
+        "census_variable": [
+            "B04006_014"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "iraq",
+        "census_variable": [
+            "B05006_079"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "asia",
+        "census_variable": [
+            "B05006_047"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pakistan",
+        "census_variable": [
+            "B05006_063"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hhpop",
+        "census_variable": [
+            "DP02_0017"
+        ],
+        "base_variable": "hhpop",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "dfhsus",
+        "census_variable": [
+            "DP02_0080"
+        ],
+        "base_variable": "dfhs2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "russia",
+        "census_variable": [
+            "B05006_040"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "bosniah",
+        "census_variable": [
+            "B05006_042"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "italy",
+        "census_variable": [
+            "B05006_023"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hongkong",
+        "census_variable": [
+            "B05006_051"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "korea",
+        "census_variable": [
+            "B05006_054"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "kzkhstan",
+        "census_variable": [
+            "B05006_061"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "denmark",
+        "census_variable": [
+            "B05006_009"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "stvgren",
+        "census_variable": [
+            "B05006_133"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "arab",
+        "census_variable": [
+            "B04006_006"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "wasia",
+        "census_variable": [
+            "B05006_078"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "neur",
+        "census_variable": [
+            "B05006_003"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "maltese",
+        "census_variable": [
+            "B04006_056"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "sam",
+        "census_variable": [
+            "B05006_147"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "swiss",
+        "census_variable": [
+            "B04006_090"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ugandan",
+        "census_variable": [
+            "B04006_085"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "dfhssmcnt",
+        "census_variable": [
+            "DP02_0081"
+        ],
+        "base_variable": "dfhs2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "srilanka",
+        "census_variable": [
+            "B05006_064"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ireland",
+        "census_variable": [
+            "B05006_008"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nafr",
+        "census_variable": [
+            "B05006_100"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "kenyan",
+        "census_variable": [
+            "B04006_077"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "moroccan",
+        "census_variable": [
+            "B04006_011"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "haiti",
+        "census_variable": [
+            "B05006_131"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "iraqi",
+        "census_variable": [
+            "B04006_008"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "uzbkstan",
+        "census_variable": [
+            "B05006_065"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ea_bchd",
+        "census_variable": [
+            "DP02_0064"
+        ],
+        "base_variable": "ea_p25pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "czchslv",
+        "census_variable": [
+            "B05006_032"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "guyanese",
+        "census_variable": [
+            "B04006_045"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ea_9t12nd",
+        "census_variable": [
+            "DP02_0060"
+        ],
+        "base_variable": "ea_p25pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "scot",
+        "census_variable": [
+            "B05006_007"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "kenya",
+        "census_variable": [
+            "B05006_095"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mcdonia",
+        "census_variable": [
+            "B05006_036"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "se_g9t12",
+        "census_variable": [
+            "DP02_0056"
+        ],
+        "base_variable": "pop3plen",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "frnotbsq",
+        "census_variable": [
+            "B04006_040"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "syrian",
+        "census_variable": [
+            "B04006_013"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "cvpop18pl",
+        "census_variable": [
+            "DP02_0068"
+        ],
+        "base_variable": "cvpop18pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "jamaican",
+        "census_variable": [
+            "B04006_102"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fb3",
+        "census_variable": [
+            "DP02_0093"
+        ],
+        "base_variable": "fb3",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "se_clggsc",
+        "census_variable": [
+            "DP02_0057"
+        ],
+        "base_variable": "pop3plen",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "osam",
+        "census_variable": [
+            "B05006_158"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "carprusn",
+        "census_variable": [
+            "B04006_027"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "switzrld",
+        "census_variable": [
+            "B05006_019"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "afg",
+        "census_variable": [
+            "B04006_002"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "carib",
+        "census_variable": [
+            "B05006_124"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hh1plu18",
+        "census_variable": [
+            "DP02_0013"
+        ],
+        "base_variable": "hh1",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "china",
+        "census_variable": [
+            "B05006_049"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "british",
+        "census_variable": [
+            "B04006_023"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ms_mwd",
+        "census_variable": [
+            "DP02_0028"
+        ],
+        "base_variable": "ms_m15pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "snglese",
+        "census_variable": [
+            "B04006_080"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "oceania",
+        "census_variable": [
+            "B05006_116"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "russian",
+        "census_variable": [
+            "B04006_064"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "gprgcu18",
+        "census_variable": [
+            "DP02_0044"
+        ],
+        "base_variable": "gplgcu18",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ocarib",
+        "census_variable": [
+            "B05006_136"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "norwgian",
+        "census_variable": [
+            "B04006_059"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "sweden",
+        "census_variable": [
+            "B05006_0011"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "trandtob",
+        "census_variable": [
+            "B05006_134"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "kuwait",
+        "census_variable": [
+            "B05006_082"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "palstnian",
+        "census_variable": [
+            "B04006_012"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "easia",
+        "census_variable": [
+            "B05006_048"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "celtic",
+        "census_variable": [
+            "B04006_028"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "subsaf",
+        "census_variable": [
+            "B04006_073"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "scandnvn",
+        "census_variable": [
+            "B04006_065"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ms_m15pl",
+        "census_variable": [
+            "DP02_0024"
+        ],
+        "base_variable": "ms_m15pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "chnohktwn",
+        "census_variable": [
+            "B05006_050"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ms_mmrdsp",
+        "census_variable": [
+            "DP02_0026"
+        ],
+        "base_variable": "ms_m15pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "othr",
+        "census_variable": [
+            "B04006_108"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "israel",
+        "census_variable": [
+            "B05006_080"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "canadian",
+        "census_variable": [
+            "B04006_026"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "dhnonyc",
+        "census_variable": [
+            "B07204_009"
+        ],
+        "base_variable": "dfhs2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "liberia",
+        "census_variable": [
+            "B05006_111"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "popinfms",
+        "census_variable": [
+            "B11002_004",
+            "B11002_007",
+            "B11002_010"
+        ],
+        "base_variable": "avgfmsz",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "sthrnafr",
+        "census_variable": [
+            "B05006_105"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "panama",
+        "census_variable": [
+            "B05006_145"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "cambodia",
+        "census_variable": [
+            "B05006_068"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "moldova",
+        "census_variable": [
+            "B05006_037"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fb2",
+        "census_variable": [
+            "DP02_0092"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "haitian",
+        "census_variable": [
+            "B04006_101"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop_5",
+        "census_variable": [
+            "DP02_0122"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "latvian",
+        "census_variable": [
+            "B04006_052"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ukrnian",
+        "census_variable": [
+            "B04006_092"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "latvia",
+        "census_variable": [
+            "B05006_034"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ea_lt9g",
+        "census_variable": [
+            "DP02_0059"
+        ],
+        "base_variable": "ea_p25pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nigerian",
+        "census_variable": [
+            "B04006_079"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "turkey",
+        "census_variable": [
+            "B05006_087"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "windnhsp",
+        "census_variable": [
+            "B04006_094"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "dominica",
+        "census_variable": [
+            "B05006_128"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ntvnys",
+        "census_variable": [
+            "DP02_0089"
+        ],
+        "base_variable": "pop_4",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ntvnotnys",
+        "census_variable": [
+            "DP02_0090"
+        ],
+        "base_variable": "pop_4",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "afr",
+        "census_variable": [
+            "B05006_091"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "indnsia",
+        "census_variable": [
+            "B05006_069"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "danish",
+        "census_variable": [
+            "B04006_033"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ethiopia",
+        "census_variable": [
+            "B05006_094"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "penngerm",
+        "census_variable": [
+            "B04006_060"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "argntina",
+        "census_variable": [
+            "B05006_148"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "peru",
+        "census_variable": [
+            "B05006_155"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "scottish",
+        "census_variable": [
+            "B04006_067"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "icelndr",
+        "census_variable": [
+            "B04006_047"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "barbados",
+        "census_variable": [
+            "B05006_126"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "swedish",
+        "census_variable": [
+            "B04006_089"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "cajun",
+        "census_variable": [
+            "B04006_025"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "scasia",
+        "census_variable": [
+            "B05006_056"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop3plen",
+        "census_variable": [
+            "DP02_0052"
+        ],
+        "base_variable": "pop3plen",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "guyana",
+        "census_variable": [
+            "B05006_154"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "vnzuela",
+        "census_variable": [
+            "B05006_157"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "dutch",
+        "census_variable": [
+            "B04006_034"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "african",
+        "census_variable": [
+            "B04006_087"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "bolivia",
+        "census_variable": [
+            "B05006_149"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "slavic",
+        "census_variable": [
+            "B04006_069"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "owind",
+        "census_variable": [
+            "B04006_106"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "omafr",
+        "census_variable": [
+            "B05006_99"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "chile",
+        "census_variable": [
+            "B05006_151"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "se_nscpsc",
+        "census_variable": [
+            "DP02_0053"
+        ],
+        "base_variable": "pop3plen",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "bahamian",
+        "census_variable": [
+            "B04006_095"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "eafr",
+        "census_variable": [
+            "B05006_092"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "armenian",
+        "census_variable": [
+            "B04006_016"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "iranian",
+        "census_variable": [
+            "B04006_048"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "basque",
+        "census_variable": [
+            "B04006_020"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "welsh",
+        "census_variable": [
+            "B04006_093"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "uruguay",
+        "census_variable": [
+            "B05006_156"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "iran",
+        "census_variable": [
+            "B05006_060"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mexico",
+        "census_variable": [
+            "B05006_138"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "italian",
+        "census_variable": [
+            "B04006_051"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ausnzsbr",
+        "census_variable": [
+            "B05006_117"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ea_lthsgr",
+        "census_variable": [
+            "DP02_0059",
+            "DP02_0060"
+        ],
+        "base_variable": "ea_p25pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "eurnec",
+        "census_variable": [
+            "B05006_046"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "france",
+        "census_variable": [
+            "B05006_016"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "spain",
+        "census_variable": [
+            "B05006_025"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hhpop1",
+        "census_variable": [
+            "B11002_001"
+        ],
+        "base_variable": "avghhsz",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rshphhldr",
+        "census_variable": [
+            "DP02_0018"
+        ],
+        "base_variable": "hhpop",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "lebanese",
+        "census_variable": [
+            "B04006_010"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "turkish",
+        "census_variable": [
+            "B04006_091"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "amricas",
+        "census_variable": [
+            "B05006_122"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "estonian",
+        "census_variable": [
+            "B04006_037"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "afrnec",
+        "census_variable": [
+            "B05006_115"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rshp_othr",
+        "census_variable": [
+            "DP02_0021"
+        ],
+        "base_variable": "hhpop",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "austria",
+        "census_variable": [
+            "B05006_014"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "canada",
+        "census_variable": [
+            "B05006_160"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ms_mdvcd",
+        "census_variable": [
+            "DP02_0029"
+        ],
+        "base_variable": "ms_m15pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ms_fdvcd",
+        "census_variable": [
+            "DP02_0035"
+        ],
+        "base_variable": "ms_f15pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "cuba",
+        "census_variable": [
+            "B05006_127"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "yemen",
+        "census_variable": [
+            "B05006_086"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "eur",
+        "census_variable": [
+            "B05006_002"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "se_kndgtn",
+        "census_variable": [
+            "DP02_0054"
+        ],
+        "base_variable": "pop3plen",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fam3",
+        "census_variable": [
+            "DP02_0004"
+        ],
+        "base_variable": "avgfmsz",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "guatmala",
+        "census_variable": [
+            "B05006_142"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop1pl",
+        "census_variable": [
+            "DP02_0078"
+        ],
+        "base_variable": "pop1pl",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hh4",
+        "census_variable": [
+            "DP02_0001"
+        ],
+        "base_variable": "avghhsz",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "philipns",
+        "census_variable": [
+            "B05006_073"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "safrican",
+        "census_variable": [
+            "B04006_083"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hgrian",
+        "census_variable": [
+            "B04006_046"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "austrian",
+        "census_variable": [
+            "B04006_019"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "sthafrca",
+        "census_variable": [
+            "B05006_106"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "saudiar",
+        "census_variable": [
+            "B05006_084"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nam",
+        "census_variable": [
+            "B05006_159"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "slovene",
+        "census_variable": [
+            "B04006_071"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "lebanon",
+        "census_variable": [
+            "B05006_083"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "bermudan",
+        "census_variable": [
+            "B04006_098"
+        ],
+        "base_variable": "pop_5",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "serbia",
+        "census_variable": [
+            "B05006_044"
+        ],
+        "base_variable": "fb2",
+        "domain": "social",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop",
+        "census_variable": [
+            "B01001_001"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop25t29",
+        "census_variable": [
+            "B01001_011",
+            "B01001_035"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop40t44",
+        "census_variable": [
+            "B01001_014",
+            "B01001_038"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop0t5",
+        "census_variable": [
+            "B01001_027"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fem",
+        "census_variable": [
+            "DP05_0003"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop50t54",
+        "census_variable": [
+            "B01001_016",
+            "B01001_040"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspsam",
+        "census_variable": [
+            "B03001_016"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop35t39",
+        "census_variable": [
+            "B01001_013"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspspnsh",
+        "census_variable": [
+            "B03001_029"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop85pl",
+        "census_variable": [
+            "DP05_0016"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop55t59",
+        "census_variable": [
+            "DP05_0012"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop35t39",
+        "census_variable": [
+            "B01001_013",
+            "B01001_037"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop67t69",
+        "census_variable": [
+            "B01001_021",
+            "B01001_045"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop18t19",
+        "census_variable": [
+            "B01001_007",
+            "B01001_031"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop5t9",
+        "census_variable": [
+            "B01001_004"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop20",
+        "census_variable": [
+            "B01001_008",
+            "B01001_032"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop_1",
+        "census_variable": [
+            "DP05_0001"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop15t19",
+        "census_variable": [
+            "B01001_006",
+            "B01001_007"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop65pl2",
+        "census_variable": [
+            "DP05_0025"
+        ],
+        "base_variable": "pop65pl2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop80t84",
+        "census_variable": [
+            "B01001_048"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop20t24",
+        "census_variable": [
+            "DP05_0008"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop70t74",
+        "census_variable": [
+            "B01001_022",
+            "B01001_046"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop70t74",
+        "census_variable": [
+            "B01001_046"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hsp2",
+        "census_variable": [
+            "B03001_003"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop75t79",
+        "census_variable": [
+            "B01001_023"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdage",
+        "census_variable": [
+            "DP05_0017"
+        ],
+        "base_variable": "median",
+        "domain": "demographic",
+        "rounding": 1,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop65t66",
+        "census_variable": [
+            "B01001_020",
+            "B01001_044"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop65plf",
+        "census_variable": [
+            "DP05_0027"
+        ],
+        "base_variable": "pop65pl2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "popu5",
+        "census_variable": [
+            "DP05_0004"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nhsp",
+        "census_variable": [
+            "DP05_0071"
+        ],
+        "base_variable": "pop_2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop20t24",
+        "census_variable": [
+            "B01001_032",
+            "B01001_033",
+            "B01001_034"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspperu",
+        "census_variable": [
+            "B03001_023"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hsppr",
+        "census_variable": [
+            "B03001_005"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop55t59",
+        "census_variable": [
+            "B01001_017"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop21",
+        "census_variable": [
+            "B01001_009",
+            "B01001_033"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop60t64",
+        "census_variable": [
+            "B01001_042",
+            "B01001_043"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspcol",
+        "census_variable": [
+            "B03001_020"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop85pl",
+        "census_variable": [
+            "B01001_025"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop30t34",
+        "census_variable": [
+            "B01001_012",
+            "B01001_036"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop25t29",
+        "census_variable": [
+            "B01001_011"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspvnz",
+        "census_variable": [
+            "B03001_025"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop_3",
+        "census_variable": [
+            "B01001_001"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "popu18f",
+        "census_variable": [
+            "DP05_0023"
+        ],
+        "base_variable": "popu18_2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspec",
+        "census_variable": [
+            "B03001_021"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop25t29",
+        "census_variable": [
+            "B01001_035"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop70t74",
+        "census_variable": [
+            "B01001_022"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop35t39",
+        "census_variable": [
+            "B01001_037"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop85pl",
+        "census_variable": [
+            "B01001_049"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "nhpinh",
+        "census_variable": [
+            "DP05_0076"
+        ],
+        "base_variable": "pop_2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hsposam",
+        "census_variable": [
+            "B03001_026"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop80t84",
+        "census_variable": [
+            "B01001_024"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop62t64",
+        "census_variable": [
+            "B01001_019",
+            "B01001_043"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop0t5",
+        "census_variable": [
+            "B01001_003"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop60t64",
+        "census_variable": [
+            "DP05_0013"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop50t54",
+        "census_variable": [
+            "B01001_016",
+            "B01001_040"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop55t59",
+        "census_variable": [
+            "B01001_041"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop80t84",
+        "census_variable": [
+            "B01001_024",
+            "B01001_048"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspdom",
+        "census_variable": [
+            "B03001_007"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop15t19",
+        "census_variable": [
+            "DP05_0007"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop65pl1",
+        "census_variable": [
+            "DP05_0021"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop85pl",
+        "census_variable": [
+            "B01001_025",
+            "B01001_049"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspurg",
+        "census_variable": [
+            "B03001_024"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "popu18m",
+        "census_variable": [
+            "DP05_0022"
+        ],
+        "base_variable": "popu18_2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop35t39",
+        "census_variable": [
+            "B01001_013",
+            "B01001_037"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop75t79",
+        "census_variable": [
+            "B01001_023",
+            "B01001_047"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspchl",
+        "census_variable": [
+            "B03001_019"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspme",
+        "census_variable": [
+            "B03001_004"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop20t24",
+        "census_variable": [
+            "B01001_008",
+            "B01001_009",
+            "B01001_010"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop75t79",
+        "census_variable": [
+            "B01001_023",
+            "B01001_047"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "othnh",
+        "census_variable": [
+            "DP05_0077"
+        ],
+        "base_variable": "pop_2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspcr",
+        "census_variable": [
+            "B03001_009"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspalloth",
+        "census_variable": [
+            "B03001_031"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop40t44",
+        "census_variable": [
+            "B01001_038"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hsppan",
+        "census_variable": [
+            "B03001_013"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop10t14",
+        "census_variable": [
+            "DP05_0006"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop65t69",
+        "census_variable": [
+            "B01001_044",
+            "B01001_045"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop10t14",
+        "census_variable": [
+            "B01001_005",
+            "B01001_029"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "wtnh",
+        "census_variable": [
+            "DP05_0072"
+        ],
+        "base_variable": "pop_2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop70t74",
+        "census_variable": [
+            "B01001_022",
+            "B01001_046"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop40t44",
+        "census_variable": [
+            "B01001_014",
+            "B01001_038"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hsp1",
+        "census_variable": [
+            "DP05_0066"
+        ],
+        "base_variable": "pop_2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hsphnd",
+        "census_variable": [
+            "B03001_011"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop65t69",
+        "census_variable": [
+            "B01001_020",
+            "B01001_021",
+            "B01001_044",
+            "B01001_045"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop30t34",
+        "census_variable": [
+            "B01001_036"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop75t79",
+        "census_variable": [
+            "B01001_047"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "popu18_2",
+        "census_variable": [
+            "DP05_0024"
+        ],
+        "base_variable": "popu18_2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop80t84",
+        "census_variable": [
+            "B01001_024",
+            "B01001_048"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop50t54",
+        "census_variable": [
+            "B01001_040"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop55t59",
+        "census_variable": [
+            "B01001_017",
+            "B01001_041"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspguatm",
+        "census_variable": [
+            "B03001_010"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop45t49",
+        "census_variable": [
+            "B01001_039"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspcub",
+        "census_variable": [
+            "B03001_006"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspcam",
+        "census_variable": [
+            "B03001_008"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspspnrd",
+        "census_variable": [
+            "B03001_028"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspsalv",
+        "census_variable": [
+            "B03001_014"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop50t54",
+        "census_variable": [
+            "B01001_016"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop15t19",
+        "census_variable": [
+            "B01001_030",
+            "B01001_031"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspspam",
+        "census_variable": [
+            "B03001_030"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "aiannh",
+        "census_variable": [
+            "DP05_0074"
+        ],
+        "base_variable": "pop_2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspprg",
+        "census_variable": [
+            "B03001_022"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop0t4",
+        "census_variable": [
+            "B01001_003",
+            "B01001_027"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "popu181",
+        "census_variable": [
+            "B05003_003",
+            "B05003_014"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspocam",
+        "census_variable": [
+            "B03001_015"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop10t14",
+        "census_variable": [
+            "B01001_005"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop45t49",
+        "census_variable": [
+            "B01001_015"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop_2",
+        "census_variable": [
+            "DP05_0065"
+        ],
+        "base_variable": "pop_2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop30t34",
+        "census_variable": [
+            "B01001_012"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop60t64",
+        "census_variable": [
+            "B01001_018",
+            "B01001_019"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop30t34",
+        "census_variable": [
+            "B01001_012",
+            "B01001_036"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop5t9",
+        "census_variable": [
+            "B01001_004",
+            "B01001_028"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop60t61",
+        "census_variable": [
+            "B01001_018",
+            "B01001_042"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop40t44",
+        "census_variable": [
+            "B01001_014"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop22t24",
+        "census_variable": [
+            "B01001_010",
+            "B01001_034"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "blnh",
+        "census_variable": [
+            "DP05_0073"
+        ],
+        "base_variable": "pop_2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "asnnh",
+        "census_variable": [
+            "DP05_0075"
+        ],
+        "base_variable": "pop_2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop15t17",
+        "census_variable": [
+            "B01001_006",
+            "B01001_030"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspbol",
+        "census_variable": [
+            "B03001_018"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "rc2plnh",
+        "census_variable": [
+            "DP05_0078"
+        ],
+        "base_variable": "pop_2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop45t49",
+        "census_variable": [
+            "B01001_015",
+            "B01001_039"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop65plm",
+        "census_variable": [
+            "DP05_0026"
+        ],
+        "base_variable": "pop65pl2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "pop5t9",
+        "census_variable": [
+            "DP05_0005"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspnic",
+        "census_variable": [
+            "B03001_012"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hsparg",
+        "census_variable": [
+            "B03001_017"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "hspoth",
+        "census_variable": [
+            "B03001_027"
+        ],
+        "base_variable": "hsp2",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "male",
+        "census_variable": [
+            "DP05_0002"
+        ],
+        "base_variable": "pop_1",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop10t14",
+        "census_variable": [
+            "B01001_029"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mpop65t69",
+        "census_variable": [
+            "B01001_020",
+            "B01001_021"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop25t29",
+        "census_variable": [
+            "B01001_011",
+            "B01001_035"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "mdpop45t49",
+        "census_variable": [
+            "B01001_015",
+            "B01001_039"
+        ],
+        "base_variable": "mdage",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "fpop5t9",
+        "census_variable": [
+            "B01001_028"
+        ],
+        "base_variable": "pop",
+        "domain": "demographic",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "ov1milpl",
+        "census_variable": [
+            "B25075_025"
+        ],
+        "base_variable": "mdvl",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
+    },
+    {
+        "pff_variable": "r2000pl",
+        "census_variable": [
+            "B25063_023"
+        ],
+        "base_variable": "mdgr",
+        "domain": "housing",
+        "rounding": 0,
+        "source": ""
     }
 ]


### PR DESCRIPTION
this should address #153 

Script used to generate this file:
```python
import pandas as pd
import requests
import ast
import json

df = pd.read_csv('meta2010.csv')
df['census_variable'] = df['census_variable'].apply(ast.literal_eval)
df['rounding'] = df['rounding'].fillna('0').astype(int)
df['source'] = ''
df = df.loc[df.Notes != 'remove', ['pff_variable','census_variable', 'base_variable', 'domain', 'rounding', 'source']]
df_dict = df.to_dict('records')
with open('metadata.json', 'w') as f:
    json.dump(df_dict, f, indent=4)
```

Running in github actions to test out results:
https://github.com/NYCPlanning/db-factfinder/actions/runs/1052808059