### PR TITLE
Fix empty list and geoid index error

### DIFF
--- a/factfinder/calculate.py
+++ b/factfinder/calculate.py
@@ -163,7 +163,8 @@ class Calculate:
                 m = md.median_moe
             except:
                 print("\n\n ======= MOE error =======")
-                print(f"\n\nranges: {md.ranges}")
+                print(f"Number of bins: {len(list(md.ranges))}")
+                print(f"ranges: {md.ranges}")
                 print(f"B: {md.B}")
                 print(f"se_50: {md.se_50}")
                 print(f"p_lower: {md.p_lower}")

--- a/factfinder/calculate.py
+++ b/factfinder/calculate.py
@@ -151,9 +151,20 @@ class Calculate:
 
         def get_median_and_median_moe(ranges, row, DF):
             md = Median(ranges, row, DF)
-            e = md.median
-            m = md.median_moe
-            return pd.Series({'e': e, 'm': m})
+            try:
+                e = md.median
+                m = md.median_moe
+                return pd.Series({'e': e, 'm': m})
+            except:
+                print(f"ranges: {md.ranges}")
+                print(f"B: {md.B}")
+                print(f"se_50: {md.se_50}")
+                print(f"p_lower: {md.p_lower}")
+                print(f"p_upper: {md.p_upper}")
+                print(f"cumm_dist: {md.cumm_dist}")
+                print(f"lower_bin: {md.lower_bin}")
+                print(f"upper_bin: {md.upper_bin}")
+                return None
 
         results = df_pivoted.e.apply(lambda x: get_median_and_median_moe(
             ranges, x, DF=design_factor), axis=1)

--- a/factfinder/calculate.py
+++ b/factfinder/calculate.py
@@ -151,28 +151,8 @@ class Calculate:
 
         def get_median_and_median_moe(ranges, row, DF):
             md = Median(ranges, row, DF)
-            try:
-                e = md.median
-            except:
-                print("\n\n ===== Estimate error =====")
-                print(f"ranges: {md.ranges}")
-                print(f"B: {md.B}")
-                print(f"cumm_dist: {md.cumm_dist}")
-                return None
-            try:
-                m = md.median_moe
-            except:
-                print("\n\n ======= MOE error =======")
-                print(f"Number of bins: {len(list(md.ranges))}")
-                print(f"ranges: {md.ranges}")
-                print(f"B: {md.B}")
-                print(f"se_50: {md.se_50}")
-                print(f"p_lower: {md.p_lower}")
-                print(f"p_upper: {md.p_upper}")
-                print(f"cumm_dist: {md.cumm_dist}")
-                print(f"lower_bin: {md.lower_bin}")
-                print(f"upper_bin: {md.upper_bin}")
-                return None
+            e = md.median
+            m = md.median_moe
             return pd.Series({'e': e, 'm': m})
 
         results = df_pivoted.e.apply(lambda x: get_median_and_median_moe(

--- a/factfinder/calculate.py
+++ b/factfinder/calculate.py
@@ -178,6 +178,7 @@ class Calculate:
         results = df_pivoted.e.apply(lambda x: get_median_and_median_moe(
             ranges, x, DF=design_factor), axis=1)
         results["census_geoid"] = df_pivoted.index
+        results = results.reset_index(drop=True)
         results["pff_variable"] = pff_variable
         results["geotype"] = geotype
         return results[["census_geoid", "pff_variable", "geotype", "e", "m"]]

--- a/factfinder/calculate.py
+++ b/factfinder/calculate.py
@@ -156,6 +156,8 @@ class Calculate:
                 m = md.median_moe
                 return pd.Series({'e': e, 'm': m})
             except:
+                print(f"pff_variable: {row.pff_variable}")
+                print(f"pff_variable: {row.census_geoid}")
                 print(f"ranges: {md.ranges}")
                 print(f"B: {md.B}")
                 print(f"se_50: {md.se_50}")

--- a/factfinder/calculate.py
+++ b/factfinder/calculate.py
@@ -153,12 +153,17 @@ class Calculate:
             md = Median(ranges, row, DF)
             try:
                 e = md.median
-                m = md.median_moe
-                return pd.Series({'e': e, 'm': m})
             except:
-                print(f"pff_variable: {row.pff_variable}")
-                print(f"pff_variable: {row.census_geoid}")
+                print("\n\n ===== Estimate error =====")
                 print(f"ranges: {md.ranges}")
+                print(f"B: {md.B}")
+                print(f"cumm_dist: {md.cumm_dist}")
+                return None
+            try:
+                m = md.median_moe
+            except:
+                print("\n\n ======= MOE error =======")
+                print(f"\n\nranges: {md.ranges}")
                 print(f"B: {md.B}")
                 print(f"se_50: {md.se_50}")
                 print(f"p_lower: {md.p_lower}")
@@ -167,6 +172,7 @@ class Calculate:
                 print(f"lower_bin: {md.lower_bin}")
                 print(f"upper_bin: {md.upper_bin}")
                 return None
+            return pd.Series({'e': e, 'm': m})
 
         results = df_pivoted.e.apply(lambda x: get_median_and_median_moe(
             ranges, x, DF=design_factor), axis=1)

--- a/factfinder/median.py
+++ b/factfinder/median.py
@@ -17,15 +17,10 @@ class Median:
             [self.cumm_dist.index(i)
              for i in self.cumm_dist if i > self.p_lower]
         ) if self.B != 0 else np.nan
-        if self.B != 0 and self.se_50 <= 50:
-            self.upper_bin = min(
-                [self.cumm_dist.index(i)
-                    for i in self.cumm_dist if i > self.p_upper]
-            ) 
-        elif self.B != 0 and self.se_50 > 50:
-            self.upper_bin = len(list(self.ranges)) - 1
-        else:
-            self.upper_bin = np.nan
+        self.upper_bin = min(
+            [self.cumm_dist.index(i)
+             for i in self.cumm_dist if i > self.p_upper], default=np.nan
+        ) if self.B != 0 else np.nan
         self.row = row
 
     @property
@@ -85,8 +80,8 @@ class Median:
 
     def base_case(self, _bin):
         # and not equal to first_non_zero_bin
-        A1 = min(self.ranges[self.ordered[_bin]])
-        A2 = min(self.ranges[self.ordered[_bin + 1]])
+        A1 = min(self.ranges[self.ordered[_bin]], default=np.nan)
+        A2 = min(self.ranges[self.ordered[_bin + 1]], default=np.nan)
         C1 = self.cumm_dist[_bin - 1]
         C2 = self.cumm_dist[_bin]
         return A1, A2, C1, C2
@@ -124,13 +119,13 @@ class Median:
 
         if self.upper_bin + 1 > len(self.ordered) - 1:
             logging.debug("upper_bin is in top bin")
-            A1 = min(self.ranges[self.ordered[self.upper_bin]])
+            A1 = min(self.ranges[self.ordered[self.upper_bin]], default=np.nan)
             A2 = A1
 
         if self.upper_bin == self.lower_bin & self.upper_bin == self.first_non_zero_bin:
             logging.debug("upper_bin and lower_bin are in the first non-zero")
             A1 = 0
-            A2 = min(self.ranges[self.ordered[1]])
+            A2 = min(self.ranges[self.ordered[1]], default=np.nan)
 
         logging.debug(
             f"""

--- a/factfinder/median.py
+++ b/factfinder/median.py
@@ -17,10 +17,15 @@ class Median:
             [self.cumm_dist.index(i)
              for i in self.cumm_dist if i > self.p_lower]
         ) if self.B != 0 else np.nan
-        self.upper_bin = min(
-            [self.cumm_dist.index(i)
-             for i in self.cumm_dist if i > self.p_upper]
-        ) if self.B != 0 and self.se_50 <= 50 else np.nan
+        if self.B != 0 and self.se_50 <= 50:
+            self.upper_bin = min(
+                [self.cumm_dist.index(i)
+                    for i in self.cumm_dist if i > self.p_upper]
+            ) 
+        elif self.B != 0 and self.se_50 > 50:
+            self.upper_bin = len(list(self.ranges)) - 1
+        else:
+            self.upper_bin = np.nan
         self.row = row
 
     @property

--- a/factfinder/median.py
+++ b/factfinder/median.py
@@ -76,7 +76,10 @@ class Median:
 
     @staticmethod
     def get_bound(p, A1, A2, C1, C2):
-        return (p - C1) * (A2 - A1) / (C2 - C1) + A1
+        if ((C2 - C1) + A1) != 0:
+            return (p - C1) * (A2 - A1) / (C2 - C1) + A1
+        else:
+            return np.nan
 
     def base_case(self, _bin):
         # and not equal to first_non_zero_bin

--- a/factfinder/median.py
+++ b/factfinder/median.py
@@ -20,7 +20,7 @@ class Median:
         self.upper_bin = min(
             [self.cumm_dist.index(i)
              for i in self.cumm_dist if i > self.p_upper]
-        ) if self.B != 0 else np.nan
+        ) if self.B != 0 and self.se_50 <= 50 else np.nan
         self.row = row
 
     @property

--- a/factfinder/median.py
+++ b/factfinder/median.py
@@ -81,7 +81,7 @@ class Median:
     def base_case(self, _bin):
         # and not equal to first_non_zero_bin
         A1 = min(self.ranges[self.ordered[_bin]], default=np.nan)
-        A2 = min(self.ranges[self.ordered[_bin + 1]], default=np.nan)
+        A2 = min(self.ranges[self.ordered[_bin + 1]], default=np.nan) if _bin + 1 <= len(self.ordered) - 1 else np.nan
         C1 = self.cumm_dist[_bin - 1]
         C2 = self.cumm_dist[_bin]
         return A1, A2, C1, C2

--- a/notebooks/median.ipynb
+++ b/notebooks/median.ipynb
@@ -118,273 +118,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "source": [
     "# Perfom e and m median calculation by calling calculate method\n",
     "df = calculate.calculate_e_m_median(pff_variable, geotype)\n",
     "df.head()\n"
    ],
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "             census_geoid pff_variable geotype             e             m\n",
-       "census_geoid                                                              \n",
-       "36005000100   36005000100      mdhhinc    CT20      0.000000           NaN\n",
-       "36005000200   36005000200      mdhhinc    CT20  59697.825301  16981.384701\n",
-       "36005000400   36005000400      mdhhinc    CT20  68407.334211  14254.802499\n",
-       "36005001600   36005001600      mdhhinc    CT20  30503.371528   5877.238287\n",
-       "36005001901   36005001901      mdhhinc    CT20  25164.440789  28494.309073"
-      ],
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>census_geoid</th>\n",
-       "      <th>pff_variable</th>\n",
-       "      <th>geotype</th>\n",
-       "      <th>e</th>\n",
-       "      <th>m</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>census_geoid</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>36005000100</th>\n",
-       "      <td>36005000100</td>\n",
-       "      <td>mdhhinc</td>\n",
-       "      <td>CT20</td>\n",
-       "      <td>0.000000</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>36005000200</th>\n",
-       "      <td>36005000200</td>\n",
-       "      <td>mdhhinc</td>\n",
-       "      <td>CT20</td>\n",
-       "      <td>59697.825301</td>\n",
-       "      <td>16981.384701</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>36005000400</th>\n",
-       "      <td>36005000400</td>\n",
-       "      <td>mdhhinc</td>\n",
-       "      <td>CT20</td>\n",
-       "      <td>68407.334211</td>\n",
-       "      <td>14254.802499</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>36005001600</th>\n",
-       "      <td>36005001600</td>\n",
-       "      <td>mdhhinc</td>\n",
-       "      <td>CT20</td>\n",
-       "      <td>30503.371528</td>\n",
-       "      <td>5877.238287</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>36005001901</th>\n",
-       "      <td>36005001901</td>\n",
-       "      <td>mdhhinc</td>\n",
-       "      <td>CT20</td>\n",
-       "      <td>25164.440789</td>\n",
-       "      <td>28494.309073</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 5
-    }
-   ],
+   "outputs": [],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "source": [
     "df.loc[df.census_geoid.isin(census_geoid_list),:]"
    ],
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "             census_geoid pff_variable geotype             e             m\n",
-       "census_geoid                                                              \n",
-       "36005043501   36005043501      mdhhinc    CT20  15208.291667  17961.681329"
-      ],
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>census_geoid</th>\n",
-       "      <th>pff_variable</th>\n",
-       "      <th>geotype</th>\n",
-       "      <th>e</th>\n",
-       "      <th>m</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>census_geoid</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>36005043501</th>\n",
-       "      <td>36005043501</td>\n",
-       "      <td>mdhhinc</td>\n",
-       "      <td>CT20</td>\n",
-       "      <td>15208.291667</td>\n",
-       "      <td>17961.681329</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 6
-    }
-   ],
+   "outputs": [],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "source": [
     "# Peform full calculation (including cleaning/rounding) to show display output\n",
     "full_calc = calculate(pff_variable, geotype)\n",
     "full_calc.loc[full_calc.census_geoid.isin(census_geoid_list),:]"
    ],
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "             census_geoid labs_geoid geotype labs_geotype pff_variable     c  \\\n",
-       "census_geoid                                                                   \n",
-       "36005043501   36005043501    2043501    CT20       CT2020      mdhhinc  71.8   \n",
-       "\n",
-       "                    e        m   p   z  \n",
-       "census_geoid                            \n",
-       "36005043501   15208.0  17962.0 NaN NaN  "
-      ],
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>census_geoid</th>\n",
-       "      <th>labs_geoid</th>\n",
-       "      <th>geotype</th>\n",
-       "      <th>labs_geotype</th>\n",
-       "      <th>pff_variable</th>\n",
-       "      <th>c</th>\n",
-       "      <th>e</th>\n",
-       "      <th>m</th>\n",
-       "      <th>p</th>\n",
-       "      <th>z</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>census_geoid</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>36005043501</th>\n",
-       "      <td>36005043501</td>\n",
-       "      <td>2043501</td>\n",
-       "      <td>CT20</td>\n",
-       "      <td>CT2020</td>\n",
-       "      <td>mdhhinc</td>\n",
-       "      <td>71.8</td>\n",
-       "      <td>15208.0</td>\n",
-       "      <td>17962.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 7
-    }
-   ],
+   "outputs": [],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "source": [
     "# Calculate inputs in 2020 geogs\n",
     "df = calculate.calculate_e_m_multiprocessing(list(ranges.keys()), geotype)"
@@ -394,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "source": [
     "# 3. create a pivot table with census_geoid as the index, and\n",
     "# pff_variable as column names. df_pivoted.e -> the estimation dataframe\n",
@@ -519,14 +284,14 @@
       ]
      },
      "metadata": {},
-     "execution_count": 9
+     "execution_count": 6
     }
    ],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "source": [
     "# Empty dataframe to store the results\n",
     "results = pd.DataFrame()\n",
@@ -580,35 +345,50 @@
       ]
      },
      "metadata": {},
-     "execution_count": 10
+     "execution_count": 11
     }
    ],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "source": [
     "import logging\n",
     "logger = logging.getLogger()\n",
     "logger.setLevel(logging.DEBUG)\n",
     "logging.debug(\"test\")\n",
     "\n",
-    "# 4. calculate median estimation using get_median\n",
-    "results[\"e\"] = (\n",
-    "    df_pivoted.e.loc[\n",
-    "        df_pivoted.e.index == results.census_geoid, list(ranges.keys())\n",
-    "    ]\n",
-    "    .apply(lambda row: Median(ranges, row, design_factor).median, axis=1)\n",
-    "    .to_list()\n",
-    ")"
+    "def get_median_and_median_moe(ranges, row, DF):\n",
+    "    md = Median(ranges, row, DF)\n",
+    "    e = md.median\n",
+    "    m = md.median_moe\n",
+    "    return pd.Series({'e': e, 'm': m})\n"
    ],
    "outputs": [
     {
      "output_type": "stream",
      "name": "stderr",
      "text": [
-      "DEBUG:root:test\n",
+      "DEBUG:root:test\n"
+     ]
+    }
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "source": [
+    "results = df_pivoted.e.apply(lambda x: get_median_and_median_moe(\n",
+    "            ranges, x, DF=design_factor), axis=1)\n",
+    "results.head()"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": [
       "DEBUG:root:N/2 is in range [15000, 19999]\n",
       "DEBUG:root:\n",
       "=================================\n",
@@ -619,32 +399,7 @@
       "=================================\n",
       "DEBUG:root:\n",
       "MEDIAN: 15208.291666666666\n",
-      "\n"
-     ]
-    }
-   ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "source": [
-    "# 5. Calculate median moe using get_median_moe\n",
-    "# Note that median moe calculation needs the median estimation\n",
-    "# so we seperated df_pivoted.m out as a seperate dataframe\n",
-    "e = df_pivoted.e.copy()\n",
-    "e[\"e\"] = results.loc[e.index == results.census_geoid, \"e\"].to_list()\n",
-    "results[\"m\"] = (\n",
-    "    e.loc[e.index == results.census_geoid, list(ranges.keys()) + [\"e\"]]\n",
-    "    .apply(lambda row: Median(ranges, row, design_factor).median_moe, axis=1)\n",
-    "    .to_list()\n",
-    ")"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
+      "\n",
       "DEBUG:root:N/2 is in range [15000, 19999]\n",
       "DEBUG:root:\n",
       "=================================\n",
@@ -713,15 +468,69 @@
       "- [200000, 9999999]: 100.0\n",
       "=================================\n"
      ]
+    },
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "                         e             m\n",
+       "census_geoid                            \n",
+       "36005043501   15208.291667  17961.681329"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>e</th>\n",
+       "      <th>m</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>census_geoid</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>36005043501</th>\n",
+       "      <td>15208.291667</td>\n",
+       "      <td>17961.681329</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 13
     }
    ],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "source": [
-    "results.head()"
+    "results[\"census_geoid\"] = df_pivoted.index\n",
+    "results = results.reset_index(drop=True)\n",
+    "results[\"pff_variable\"] = pff_variable\n",
+    "results[\"geotype\"] = geotype\n",
+    "results[[\"census_geoid\", \"pff_variable\", \"geotype\", \"e\", \"m\"]]"
    ],
    "outputs": [
     {
@@ -772,9 +581,53 @@
       ]
      },
      "metadata": {},
-     "execution_count": 13
+     "execution_count": 14
     }
    ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "\n",
+    "# 4. calculate median estimation using get_median\n",
+    "results[\"e\"] = (\n",
+    "    df_pivoted.e.loc[\n",
+    "        df_pivoted.e.index == results.census_geoid, list(ranges.keys())\n",
+    "    ]\n",
+    "    .apply(lambda row: Median(ranges, row, design_factor).median, axis=1)\n",
+    "    .to_list()\n",
+    ")"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "# 5. Calculate median moe using get_median_moe\n",
+    "# Note that median moe calculation needs the median estimation\n",
+    "# so we seperated df_pivoted.m out as a seperate dataframe\n",
+    "e = df_pivoted.e.copy()\n",
+    "e[\"e\"] = results.loc[e.index == results.census_geoid, \"e\"].to_list()\n",
+    "results[\"m\"] = (\n",
+    "    e.loc[e.index == results.census_geoid, list(ranges.keys()) + [\"e\"]]\n",
+    "    .apply(lambda row: Median(ranges, row, design_factor).median_moe, axis=1)\n",
+    "    .to_list()\n",
+    ")"
+   ],
+   "outputs": [],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "source": [
+    "results.head()"
+   ],
+   "outputs": [],
    "metadata": {}
   }
  ],

--- a/notebooks/median.ipynb
+++ b/notebooks/median.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "source": [
     "##INPUTS -- change here\n",
     "pff_variable = 'mdhhinc'\n",
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "source": [
     "# See all digits of ratio\n",
     "ratio = calculate.geo.ratio\n",
@@ -90,14 +90,14 @@
       ]
      },
      "metadata": {},
-     "execution_count": 4
+     "execution_count": 3
     }
    ],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "source": [
     "# Get ranges and design factor from metadata\n",
     "ranges = calculate.meta.median_ranges(pff_variable)\n",
@@ -118,7 +118,273 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
+   "source": [
+    "# Perfom e and m median calculation by calling calculate method\n",
+    "df = calculate.calculate_e_m_median(pff_variable, geotype)\n",
+    "df.head()\n"
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "             census_geoid pff_variable geotype             e             m\n",
+       "census_geoid                                                              \n",
+       "36005000100   36005000100      mdhhinc    CT20      0.000000           NaN\n",
+       "36005000200   36005000200      mdhhinc    CT20  59697.825301  16981.384701\n",
+       "36005000400   36005000400      mdhhinc    CT20  68407.334211  14254.802499\n",
+       "36005001600   36005001600      mdhhinc    CT20  30503.371528   5877.238287\n",
+       "36005001901   36005001901      mdhhinc    CT20  25164.440789  28494.309073"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>census_geoid</th>\n",
+       "      <th>pff_variable</th>\n",
+       "      <th>geotype</th>\n",
+       "      <th>e</th>\n",
+       "      <th>m</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>census_geoid</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>36005000100</th>\n",
+       "      <td>36005000100</td>\n",
+       "      <td>mdhhinc</td>\n",
+       "      <td>CT20</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>36005000200</th>\n",
+       "      <td>36005000200</td>\n",
+       "      <td>mdhhinc</td>\n",
+       "      <td>CT20</td>\n",
+       "      <td>59697.825301</td>\n",
+       "      <td>16981.384701</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>36005000400</th>\n",
+       "      <td>36005000400</td>\n",
+       "      <td>mdhhinc</td>\n",
+       "      <td>CT20</td>\n",
+       "      <td>68407.334211</td>\n",
+       "      <td>14254.802499</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>36005001600</th>\n",
+       "      <td>36005001600</td>\n",
+       "      <td>mdhhinc</td>\n",
+       "      <td>CT20</td>\n",
+       "      <td>30503.371528</td>\n",
+       "      <td>5877.238287</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>36005001901</th>\n",
+       "      <td>36005001901</td>\n",
+       "      <td>mdhhinc</td>\n",
+       "      <td>CT20</td>\n",
+       "      <td>25164.440789</td>\n",
+       "      <td>28494.309073</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 5
+    }
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
    "execution_count": 6,
+   "source": [
+    "df.loc[df.census_geoid.isin(census_geoid_list),:]"
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "             census_geoid pff_variable geotype             e             m\n",
+       "census_geoid                                                              \n",
+       "36005043501   36005043501      mdhhinc    CT20  15208.291667  17961.681329"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>census_geoid</th>\n",
+       "      <th>pff_variable</th>\n",
+       "      <th>geotype</th>\n",
+       "      <th>e</th>\n",
+       "      <th>m</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>census_geoid</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>36005043501</th>\n",
+       "      <td>36005043501</td>\n",
+       "      <td>mdhhinc</td>\n",
+       "      <td>CT20</td>\n",
+       "      <td>15208.291667</td>\n",
+       "      <td>17961.681329</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 6
+    }
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "source": [
+    "# Peform full calculation (including cleaning/rounding) to show display output\n",
+    "full_calc = calculate(pff_variable, geotype)\n",
+    "full_calc.loc[full_calc.census_geoid.isin(census_geoid_list),:]"
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "             census_geoid labs_geoid geotype labs_geotype pff_variable     c  \\\n",
+       "census_geoid                                                                   \n",
+       "36005043501   36005043501    2043501    CT20       CT2020      mdhhinc  71.8   \n",
+       "\n",
+       "                    e        m   p   z  \n",
+       "census_geoid                            \n",
+       "36005043501   15208.0  17962.0 NaN NaN  "
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>census_geoid</th>\n",
+       "      <th>labs_geoid</th>\n",
+       "      <th>geotype</th>\n",
+       "      <th>labs_geotype</th>\n",
+       "      <th>pff_variable</th>\n",
+       "      <th>c</th>\n",
+       "      <th>e</th>\n",
+       "      <th>m</th>\n",
+       "      <th>p</th>\n",
+       "      <th>z</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>census_geoid</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>36005043501</th>\n",
+       "      <td>36005043501</td>\n",
+       "      <td>2043501</td>\n",
+       "      <td>CT20</td>\n",
+       "      <td>CT2020</td>\n",
+       "      <td>mdhhinc</td>\n",
+       "      <td>71.8</td>\n",
+       "      <td>15208.0</td>\n",
+       "      <td>17962.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 7
+    }
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "source": [
     "# Calculate inputs in 2020 geogs\n",
     "df = calculate.calculate_e_m_multiprocessing(list(ranges.keys()), geotype)"
@@ -128,7 +394,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "source": [
     "# 3. create a pivot table with census_geoid as the index, and\n",
     "# pff_variable as column names. df_pivoted.e -> the estimation dataframe\n",
@@ -253,14 +519,14 @@
       ]
      },
      "metadata": {},
-     "execution_count": 7
+     "execution_count": 9
     }
    ],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "source": [
     "# Empty dataframe to store the results\n",
     "results = pd.DataFrame()\n",
@@ -314,14 +580,14 @@
       ]
      },
      "metadata": {},
-     "execution_count": 8
+     "execution_count": 10
     }
    ],
    "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "source": [
     "import logging\n",
     "logger = logging.getLogger()\n",
@@ -361,7 +627,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "source": [
     "# 5. Calculate median moe using get_median_moe\n",
     "# Note that median moe calculation needs the median estimation\n",
@@ -453,22 +719,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "source": [
     "results.head()"
    ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "source": [
-    "# Peform full calculation (including cleaning/rounding) to show display output\n",
-    "full_calc = calculate(pff_variable, geotype)\n",
-    "full_calc.loc[full_calc.census_geoid.isin(census_geoid_list),:]"
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "  census_geoid pff_variable geotype             e             m\n",
+       "0  36005043501      mdhhinc    CT20  15208.291667  17961.681329"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>census_geoid</th>\n",
+       "      <th>pff_variable</th>\n",
+       "      <th>geotype</th>\n",
+       "      <th>e</th>\n",
+       "      <th>m</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>36005043501</td>\n",
+       "      <td>mdhhinc</td>\n",
+       "      <td>CT20</td>\n",
+       "      <td>15208.291667</td>\n",
+       "      <td>17961.681329</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 13
+    }
    ],
-   "outputs": [],
    "metadata": {}
   }
  ],


### PR DESCRIPTION
- Check to make sure that upper bound is not in top bin before setting A2 in base case
- Use default np.nan in min functions
- Reset index after applying get_median_and_median_moe
- Fix divide-by-zero warning