### PR TITLE
Change 'mean' base vars to 'nan'

### DIFF
--- a/factfinder/data/acs/2010/metadata.json
+++ b/factfinder/data/acs/2010/metadata.json
@@ -439,7 +439,7 @@
         "census_variable": [
             "DP03_0025"
         ],
-        "base_variable": "mean",
+        "base_variable": "nan",
         "domain": "economic",
         "rounding": 1,
         "category": "Commute to Work"
@@ -1479,7 +1479,7 @@
         "census_variable": [
             "DP03_0063"
         ],
-        "base_variable": "mean",
+        "base_variable": "nan",
         "domain": "economic",
         "rounding": 0,
         "category": "Income and Benefits"
@@ -1780,7 +1780,7 @@
         "census_variable": [
             "DP03_0088"
         ],
-        "base_variable": "mean",
+        "base_variable": "nan",
         "domain": "economic",
         "rounding": 0,
         "category": "Income and Benefits"
@@ -3234,7 +3234,7 @@
         "census_variable": [
             "DP04_0048"
         ],
-        "base_variable": "mean",
+        "base_variable": "nan",
         "domain": "housing",
         "rounding": 2,
         "category": "Housing Tenure"
@@ -3455,7 +3455,7 @@
         "census_variable": [
             "DP04_0047"
         ],
-        "base_variable": "mean",
+        "base_variable": "nan",
         "domain": "housing",
         "rounding": 2,
         "category": "Housing Tenure"
@@ -4065,7 +4065,7 @@
         "census_variable": [
             "DP02_0016"
         ],
-        "base_variable": "mean",
+        "base_variable": "nan",
         "domain": "social",
         "rounding": 2,
         "category": "Household Type"
@@ -4567,7 +4567,7 @@
         "census_variable": [
             "DP02_0015"
         ],
-        "base_variable": "mean",
+        "base_variable": "nan",
         "domain": "social",
         "rounding": 2,
         "category": "Household Type"

--- a/factfinder/data/acs/2018/metadata.json
+++ b/factfinder/data/acs/2018/metadata.json
@@ -504,7 +504,7 @@
     },
     {
         "pff_variable": "mntrvtm",
-        "base_variable": "mean",
+        "base_variable": "nan",
         "census_variable": [
             "DP03_0025"
         ],
@@ -1843,7 +1843,7 @@
     },
     {
         "pff_variable": "mnhhinc",
-        "base_variable": "mean",
+        "base_variable": "nan",
         "census_variable": [
             "DP03_0063"
         ],
@@ -2197,7 +2197,7 @@
     },
     {
         "pff_variable": "percapinc",
-        "base_variable": "mean",
+        "base_variable": "nan",
         "census_variable": [
             "DP03_0088"
         ],
@@ -4071,7 +4071,7 @@
     },
     {
         "pff_variable": "avghhsroc",
-        "base_variable": "mean",
+        "base_variable": "nan",
         "census_variable": [
             "DP04_0049"
         ],
@@ -4352,7 +4352,7 @@
     },
     {
         "pff_variable": "avghhsooc",
-        "base_variable": "mean",
+        "base_variable": "nan",
         "census_variable": [
             "DP04_0048"
         ],
@@ -5053,7 +5053,7 @@
     },
     {
         "pff_variable": "avgfmsz",
-        "base_variable": "mean",
+        "base_variable": "nan",
         "census_variable": [
             "DP02_0016"
         ],
@@ -5644,7 +5644,7 @@
     },
     {
         "pff_variable": "avghhsz",
-        "base_variable": "mean",
+        "base_variable": "nan",
         "census_variable": [
             "DP02_0015"
         ],

--- a/factfinder/data/acs/2019/metadata.json
+++ b/factfinder/data/acs/2019/metadata.json
@@ -504,7 +504,7 @@
     },
     {
         "pff_variable": "mntrvtm",
-        "base_variable": "mean",
+        "base_variable": "nan",
         "census_variable": [
             "DP03_0025"
         ],
@@ -1843,7 +1843,7 @@
     },
     {
         "pff_variable": "mnhhinc",
-        "base_variable": "mean",
+        "base_variable": "nan",
         "census_variable": [
             "DP03_0063"
         ],
@@ -2197,7 +2197,7 @@
     },
     {
         "pff_variable": "percapinc",
-        "base_variable": "mean",
+        "base_variable": "nan",
         "census_variable": [
             "DP03_0088"
         ],
@@ -4071,7 +4071,7 @@
     },
     {
         "pff_variable": "avghhsroc",
-        "base_variable": "mean",
+        "base_variable": "nan",
         "census_variable": [
             "DP04_0049"
         ],
@@ -4352,7 +4352,7 @@
     },
     {
         "pff_variable": "avghhsooc",
-        "base_variable": "mean",
+        "base_variable": "nan",
         "census_variable": [
             "DP04_0048"
         ],
@@ -5045,7 +5045,7 @@
     },
     {
         "pff_variable": "avgfmsz",
-        "base_variable": "mean",
+        "base_variable": "nan",
         "census_variable": [
             "DP02_0017"
         ],
@@ -5625,7 +5625,7 @@
     },
     {
         "pff_variable": "avghhsz",
-        "base_variable": "mean",
+        "base_variable": "nan",
         "census_variable": [
             "DP02_0016"
         ],


### PR DESCRIPTION
To avoid calling these lines on 'mean':
https://github.com/NYCPlanning/db-factfinder/blob/41a7f2f9283de40e367f0332704d74a69c1cfd5a/factfinder/calculate.py#L258-L259

Because base of 'mean' passes:
https://github.com/NYCPlanning/db-factfinder/blob/41a7f2f9283de40e367f0332704d74a69c1cfd5a/factfinder/calculate.py#L245

I can't find anywhere else where a base of 'mean' determines calculation. Test once API is more stable before merging.