### PR TITLE
adding special outlier removal process for city/borough level

### DIFF
--- a/factfinder/download.py
+++ b/factfinder/download.py
@@ -54,10 +54,12 @@ class Download:
         geoqueries = self.geoqueries.get(geotype)
         dfs = []
         for geoquery in geoqueries:
-            dfs.append(download_function(geoquery, v))
+            dfs.append(download_function(geotype, geoquery, v))
         return pd.concat(dfs)
 
-    def download_e_m_p_z(self, geoquery: dict, v: Variable) -> pd.DataFrame:
+    def download_e_m_p_z(
+        self, geotype: str, geoquery: dict, v: Variable
+    ) -> pd.DataFrame:
         """
         This function is for downloading non-aggregated-geotype and data profile only
         variables. It will return e, m, p, z variables for a single pff variable.
@@ -75,11 +77,16 @@ class Download:
             df[var] = df[var].astype("float64")
         df.loc[df[E_variables].isin(outliers), M_variables] = np.nan
         df.loc[df[E_variables] == 0, M_variables] = 0
+        # 555555555 indicates controled value,
+        # for city and borough, we will set it to 0
+        if geotype in ("city", "borough"):
+            df.loc[df[M_variables].isin([-555555555, 555555555]), M_variables] = 0
+            df.loc[df[PM_variables].isin([-555555555, 555555555]), PM_variables] = 0
         # Replace all outliers as Nan
         df = df.replace(outliers, np.nan)
         return df
 
-    def download_e_m(self, geoquery: dict, v: Variable) -> pd.DataFrame:
+    def download_e_m(self, geotype: str, geoquery: dict, v: Variable) -> pd.DataFrame:
         """
         this function works in conjunction with download_variable,
         and is only created to facilitate multiprocessing, this function
@@ -124,6 +131,10 @@ class Download:
                 df.loc[df[f"{i}E"].isin(outliers), f"{i}M"] = np.nan
             else:
                 df[i] = df[i].astype("float64")
+        # 555555555 indicates controled value,
+        # for city and borough, we will set it to 0
+        if geotype in ("city", "borough"):
+            df.loc[df[M_variables].isin([-555555555, 555555555]), M_variables] = 0
         # Replace all outliers as Nan
         df = df.replace(outliers, np.nan)
         return df


### PR DESCRIPTION
controlled variables so that cv is not null

> this is only the case for NYC and boroughs, in the data download these instances would appear as *****, it seems like in the API it is appearing in this case as "-555555555". This means the estimate is controlled. Rather than keeping the MOE null, we decided to show it as 0. This seems to be working sometimes in your code because the MOEs and percent MOEs are appearing as 0, but the CV is not calculated for some of these cases. I'm not sure the implementation step, but this issue of controlled estimates is only for NYC and boroughs.

#### Context
CV is missing for ACS data where MOE=0 for NYC and boroughs. 
CV should equal 0. (Row should not be gray)

Check data:
2015-2019
PopU181: Brooklyn & Queens
Pop65pl: Queens
Pop65plM: Queens
Pop65plF: Queens
Hsp1: NYC and all boroughs
NHsp: NYC and all boroughs
Pop_1: NYC and all boroughs-- ok
PopU18_2: Brooklyn & Queens-- ok
Pop65pl2: Queens-- ok
Pop_2: NYC and all boroughs-- ok
Hsp2: NYC and all boroughs-- ok
2006-2010
PopU5: Queens
Pop65pl1: Queens
Pop65plM: Queens
Pop65plF: Queens
Hsp1: NYC and all boroughs
NHsp: NYC and all boroughs
Pop_1: NYC and all boroughs-- ok
Pop25t29: Queens-- ok
Pop30t34: Queens-- ok
Pop45t49: Queens-- ok
Pop50t54: Brooklyn, Manhattan, Queens-- ok
Pop65pl2: Queens-- ok
Pop_2: NYC and all boroughs-- ok
Hsp2: NYC and all boroughs-- ok

https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_apis/wit/attachments/4084dd3a-de6e-4b74-949d-b17a98092e1a?fileName=image.png

[#AB5191](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/5191)