### PR TITLE
232 upload ase output manual update to do

### DIFF
--- a/.github/workflows/acs_2020_manual_update.yml
+++ b/.github/workflows/acs_2020_manual_update.yml
@@ -49,4 +49,4 @@ jobs:
       - name: upload to s3
         run: |
           ACS_FILE_PATH=.output/acs/year=$DATA_YEAR/geography=$GEO_YEAR/acs_manual_update.csv
-          mc cp $ACS_FILE_PATH spaces/edm-publishing/db-factfinder/acs/year=$DATA_YEAR/geography=$GEO_YEAR/
+          mc cp $ACS_FILE_PATH spaces/edm-publishing/db-factfinder/acs/year=$DATA_YEAR/geography=$GEO_YEAR/acs.csv

--- a/.github/workflows/acs_2020_manual_update.yml
+++ b/.github/workflows/acs_2020_manual_update.yml
@@ -50,5 +50,5 @@ jobs:
 
       - name: upload to s3
         run: |
-          ACS_FILE_PATH=.output/acs/2020/2020/acs_manual_update.csv
+          ACS_FILE_PATH=.output/acs/year=2020/geography=2020/acs_manual_update.csv
           mc cp $ACS_FILE_PATH spaces/edm-publishing/db-factfinder/acs/year=2020/geography=2020/

--- a/.github/workflows/acs_2020_manual_update.yml
+++ b/.github/workflows/acs_2020_manual_update.yml
@@ -17,6 +17,7 @@ jobs:
   build:
     name: "ACS Manual Update Year: ${{ github.event.inputs.data_year }} Geography: ${{ github.event.inputs.geo_year }}"
     env:
+      API_KEY: ${{ secrets.API_KEY }}
       EDM_DATA: ${{ secrets.EDM_DATA }}
       DATA_YEAR: ${{ github.event.inputs.data_year }}
       GEO_YEAR: ${{ github.event.inputs.geo_year }}
@@ -49,5 +50,5 @@ jobs:
 
       - name: upload to s3
         run: |
-          ACS_FILE_PATH=.output/acs/$DATA_YEAR/$GEO_YEAR/acs_manual_update.csv
-          mc cp $ACS_FILE_PATH spaces/edm-publishing/db-factfinder/acs/year=$DATA_YEAR/geography=$GEO_YEAR/
+          ACS_FILE_PATH=.output/acs/2020/2020/acs_manual_update.csv
+          mc cp $ACS_FILE_PATH spaces/edm-publishing/db-factfinder/acs/year=2020/geography=2020/

--- a/.github/workflows/acs_2020_manual_update.yml
+++ b/.github/workflows/acs_2020_manual_update.yml
@@ -1,8 +1,6 @@
 name: Build - ACS 2020 Manual Update
 
 on:
-  push:
-
   workflow_dispatch:
     inputs:
       data_year:
@@ -46,9 +44,9 @@ jobs:
 
       - name: run pipelines/acs
         run: |
-          python3.9 -m pipelines.acs_2020_manual_update --year 2020 --geography 2020
+          python3.9 -m pipelines.acs_2020_manual_update --year $DATA_YEAR --geography $GEO_YEAR
 
       - name: upload to s3
         run: |
-          ACS_FILE_PATH=.output/acs/year=2020/geography=2020/acs_manual_update.csv
-          mc cp $ACS_FILE_PATH spaces/edm-publishing/db-factfinder/acs/year=2020/geography=2020/
+          ACS_FILE_PATH=.output/acs/year=$DATA_YEAR/geography=$GEO_YEAR/acs_manual_update.csv
+          mc cp $ACS_FILE_PATH spaces/edm-publishing/db-factfinder/acs/year=$DATA_YEAR/geography=$GEO_YEAR/

--- a/.github/workflows/acs_2020_manual_update.yml
+++ b/.github/workflows/acs_2020_manual_update.yml
@@ -1,0 +1,63 @@
+name: Build - ACS 2020 Manual Update
+on:
+  workflow_dispatch:
+    inputs:
+      data_year:
+        description: 'Release year of ACS data. e.g. For 2016-2020 acs5 data, type "2020"'
+        required: true
+        default: '2019'
+      geo_year:
+        description: 'Year of geographic units. Options: "2010", "2020", or "2010_to_2020"'
+        required: true
+        default: '2010_to_2020'
+      cache:
+        description: 'Would you like to use cached download data? (yes/no)'
+        required: true
+        default: 'yes'
+
+jobs:
+  build:
+    name: "ACS Year: ${{ github.event.inputs.data_year }} Geography: ${{ github.event.inputs.geo_year }}"
+    env:
+      API_KEY: ${{ secrets.API_KEY }}
+      EDM_DATA: ${{ secrets.EDM_DATA }}
+      DATA_YEAR: ${{ github.event.inputs.data_year }}
+      GEO_YEAR: ${{ github.event.inputs.geo_year }}
+      AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Install Minio CLI
+        run: |
+          curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
+          chmod +x mc
+          sudo mv ./mc /usr/bin
+          mc config host add spaces $AWS_S3_ENDPOINT $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY --api S3v4
+
+      - name: Install locally
+        run: |
+          python3.9 -m pip install --upgrade pip
+          python3.9 -m pip install .
+
+      - name: Cache Download - so that we are less reliant on the API
+        if: github.event.inputs.cache == 'yes'
+        uses: actions/cache@v2
+        with:
+          path: .cache/download/year=${{ github.event.inputs.data_year }}/geography=${{ github.event.inputs.geo_year }}
+          key: ${{ hashFiles('factfinder/download.py') }}
+
+      - name: run pipelines/acs
+        run: |
+          python3.9 -m pipelines.acs_2020_manual_update --year $DATA_YEAR --geography $GEO_YEAR
+
+      - name: upload to s3
+        run: |
+          ACS_FILE_PATH=.output/acs/$DATA_YEAR/$GEO_YEAR/acs_manual_update.csv
+          mc cp $ACS_FILE_PATH spaces/edm-publishing/db-factfinder/acs/year=$DATA_YEAR/geography=$GEO_YEAR/

--- a/.github/workflows/acs_2020_manual_update.yml
+++ b/.github/workflows/acs_2020_manual_update.yml
@@ -1,25 +1,22 @@
 name: Build - ACS 2020 Manual Update
+
 on:
+  push:
+
   workflow_dispatch:
     inputs:
       data_year:
         description: 'Release year of ACS data. e.g. For 2016-2020 acs5 data, type "2020"'
         required: true
-        default: '2019'
+        default: '2020'
       geo_year:
         description: 'Year of geographic units. Options: "2010", "2020", or "2010_to_2020"'
         required: true
         default: '2010_to_2020'
-      cache:
-        description: 'Would you like to use cached download data? (yes/no)'
-        required: true
-        default: 'yes'
-
 jobs:
   build:
-    name: "ACS Year: ${{ github.event.inputs.data_year }} Geography: ${{ github.event.inputs.geo_year }}"
+    name: "ACS Manual Update Year: ${{ github.event.inputs.data_year }} Geography: ${{ github.event.inputs.geo_year }}"
     env:
-      API_KEY: ${{ secrets.API_KEY }}
       EDM_DATA: ${{ secrets.EDM_DATA }}
       DATA_YEAR: ${{ github.event.inputs.data_year }}
       GEO_YEAR: ${{ github.event.inputs.geo_year }}
@@ -46,16 +43,9 @@ jobs:
           python3.9 -m pip install --upgrade pip
           python3.9 -m pip install .
 
-      - name: Cache Download - so that we are less reliant on the API
-        if: github.event.inputs.cache == 'yes'
-        uses: actions/cache@v2
-        with:
-          path: .cache/download/year=${{ github.event.inputs.data_year }}/geography=${{ github.event.inputs.geo_year }}
-          key: ${{ hashFiles('factfinder/download.py') }}
-
       - name: run pipelines/acs
         run: |
-          python3.9 -m pipelines.acs_2020_manual_update --year $DATA_YEAR --geography $GEO_YEAR
+          python3.9 -m pipelines.acs_2020_manual_update --year 2020 --geography 2020
 
       - name: upload to s3
         run: |


### PR DESCRIPTION
Addresses Issue #232 

Includes new Github Action for Pushing to Digital Ocean outputs of manual update scripts.

There may be an issue with getting a workflow dispatch to work on a non-main branch, unsure the correct workaround (beyond testing this with an on: push, which we could leave for this branch and just push both files)