### PR TITLE
Ingest non inflated 2010 data

### DIFF
--- a/pipelines/acs_2020_manual_update.py
+++ b/pipelines/acs_2020_manual_update.py
@@ -5,13 +5,31 @@ from typing import Tuple
 import pandas as pd
 import re
 
-OUTPUT_SCHEMA_COLUMNS = ['census_geoid', 'labs_geoid', 'geotype', 'labs_geotype', 'pff_variable', 'base_variable', 'c', 'e', 'm', 'p', 'z', 'domain']
+OUTPUT_SCHEMA_COLUMNS = [
+    "census_geoid",
+    "labs_geoid",
+    "geotype",
+    "labs_geotype",
+    "pff_variable",
+    "base_variable",
+    "c",
+    "e",
+    "m",
+    "p",
+    "z",
+    "domain",
+]
+
 
 def parse_args() -> Tuple[str, str]:
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        "-y", "--year", type=str, help="The ACS5 year, e.g. 2020 (2016-2020)", choices=['2010', '2020']
+        "-y",
+        "--year",
+        type=str,
+        help="The ACS5 year, e.g. 2020 (2016-2020)",
+        choices=["2010", "2020"],
     )
     parser.add_argument(
         "-g", "--geography", type=str, help="The geography year, e.g. 2010_to_2020"
@@ -19,51 +37,50 @@ def parse_args() -> Tuple[str, str]:
     args = parser.parse_args()
     return args.year, args.geography
 
+
 def pivot_field_name(df, field_name, domain):
     field_name_df = split_by_field_name(df, field_name)
 
-    field_name_df.rename(columns=lambda column_name: re.sub(f"^{ field_name }(E|M|C|P|Z)$",r"\1", column_name).lower(), inplace=True)
-    field_name_df['pff_variable'] = field_name.lower()
-    field_name_df['domain'] = domain
+    field_name_df.rename(
+        columns=lambda column_name: re.sub(
+            f"^{ field_name }(E|M|C|P|Z)$", r"\1", column_name
+        ).lower(),
+        inplace=True,
+    )
+    field_name_df["pff_variable"] = field_name.lower()
+    field_name_df["domain"] = domain
 
     return field_name_df
 
+
 def extract_field_names(df):
-    return df.columns.drop(['GeoType', 'GeoID']).str[:-1].drop_duplicates()
-     
+    return df.columns.drop(["GeoType", "GeoID"]).str[:-1].drop_duplicates()
+
+
 def split_by_field_name(df, pff_field_name):
     return df.filter(regex=f"^(GeoType|GeoID|{ pff_field_name }(E|M|C|P|Z))$")
 
+
 def strip_unnamed_columns(df):
-    return df.loc[:,~df.columns.str.match("Unnamed")]
+    return df.loc[:, ~df.columns.str.match("Unnamed")]
+
 
 def sheet_names(year):
-    if year == '2010':
-        sheet_name_suffix = '0610'
-        inflated = "_Inflated"
-    if year == '2020':
-        sheet_name_suffix = '1620'
+    if year == "2010":
+        sheet_name_suffix = "0610"
+        inflated = "_NotInflated"
+    if year == "2020":
+        sheet_name_suffix = "1620"
         inflated = ""
 
     domains_sheets = [
-        {
-            'domain': 'demographic',
-            'sheet_name': f'Dem{sheet_name_suffix}'
-        }, 
-        {
-            'domain': 'social',
-            'sheet_name': f'Social{sheet_name_suffix}'
-        }, 
-        {
-            'domain': 'economic',
-            'sheet_name': f'Econ{sheet_name_suffix}{inflated}'
-        }, 
-        {
-            'domain': 'housing',
-            'sheet_name': f'Housing{sheet_name_suffix}{inflated}'
-        }
+        {"domain": "demographic", "sheet_name": f"Dem{sheet_name_suffix}"},
+        {"domain": "social", "sheet_name": f"Social{sheet_name_suffix}"},
+        {"domain": "economic", "sheet_name": f"Econ{sheet_name_suffix}{inflated}"},
+        {"domain": "housing", "sheet_name": f"Housing{sheet_name_suffix}{inflated}"},
     ]
     return domains_sheets
+
 
 def transform_dataframe(df, domain):
     df = strip_unnamed_columns(df)
@@ -80,29 +97,43 @@ def transform_dataframe(df, domain):
             output_df = pd.concat([output_df, new_df], ignore_index=True)
     return output_df
 
+
 def transform_all_dataframes(year):
     domains_sheets = sheet_names(year)
     input_file = f"factfinder/data/acs_1620_update/{year}/acs_{year}.xlsx"
-    
-    dfs = pd.read_excel(input_file, sheet_name=None, engine='openpyxl')
+
+    dfs = pd.read_excel(input_file, sheet_name=None, engine="openpyxl")
     combined_df = pd.DataFrame()
 
     for domain_sheet in domains_sheets:
-        combined_df = pd.concat([combined_df, transform_dataframe(dfs[domain_sheet['sheet_name']], domain_sheet['domain'])])
+        combined_df = pd.concat(
+            [
+                combined_df,
+                transform_dataframe(
+                    dfs[domain_sheet["sheet_name"]], domain_sheet["domain"]
+                ),
+            ]
+        )
+        print(f"shape of {domain_sheet}: {combined_df.shape}")
 
-    combined_df.dropna(subset=['geotype'], inplace=True)
+    combined_df.dropna(subset=["geotype"], inplace=True)
 
     return combined_df
 
+
 def attach_base_variable(df, year):
     metadata_file = f"factfinder/data/acs/{year}/metadata.json"
-    acs_variable_mapping = pd.read_json(metadata_file)[['base_variable', 'pff_variable']]
+    acs_variable_mapping = pd.read_json(metadata_file)[
+        ["base_variable", "pff_variable"]
+    ]
 
-    return df.merge(acs_variable_mapping, how='left', on='pff_variable')
+    return df.merge(acs_variable_mapping, how="left", on="pff_variable")
+
 
 def rename_columns(df):
     df.rename(columns={"geotype": "labs_geotype", "geoid": "labs_geoid"}, inplace=True)
     return df.reindex(columns=OUTPUT_SCHEMA_COLUMNS)
+
 
 if __name__ == "__main__":
     # Get ACS year
@@ -116,4 +147,3 @@ if __name__ == "__main__":
 
     os.makedirs(output_folder, exist_ok=True)
     export_df.to_csv(f"{output_folder}/acs_manual_update.csv", index=False)
-


### PR DESCRIPTION
Addresses issue #236. The source data is changed to excel file sent on Tuesday July 5th, and python code is changed to point to `<domain>_NonInflated` instead of `<domain>Inflated` for 2010 Econ and Housing.

Summary of changes to python code are mostly caused by Andrew and I using different linters, which we should definitely work out