### PR TITLE
Remove ACS Variables from 2010 that don't match metadata file

### DIFF
--- a/pipelines/acs_2020_manual_update.py
+++ b/pipelines/acs_2020_manual_update.py
@@ -120,7 +120,7 @@ def transform_all_dataframes(year):
     return combined_df
 
 
-def attach_base_variable(df, year):
+def filter_by_metadata(df, year):
     metadata_file = f"factfinder/data/acs/{year}/metadata.json"
     acs_variable_mapping = pd.read_json(metadata_file)[
         ["pff_variable"]
@@ -140,7 +140,7 @@ if __name__ == "__main__":
     year, geography = parse_args()
 
     export_df = transform_all_dataframes(year)
-    export_df = attach_base_variable(export_df, year)
+    export_df = filter_by_metadata(export_df, year)
     export_df = rename_columns(export_df)
 
     output_folder = f".output/acs/year={year}/geography={geography}"

--- a/pipelines/acs_2020_manual_update.py
+++ b/pipelines/acs_2020_manual_update.py
@@ -123,7 +123,7 @@ def transform_all_dataframes(year):
 def attach_base_variable(df, year):
     metadata_file = f"factfinder/data/acs/{year}/metadata.json"
     acs_variable_mapping = pd.read_json(metadata_file)[
-        ["base_variable", "pff_variable"]
+        ["pff_variable"]
     ]
 
     return df.merge(acs_variable_mapping, how="inner", on="pff_variable")

--- a/pipelines/acs_2020_manual_update.py
+++ b/pipelines/acs_2020_manual_update.py
@@ -11,7 +11,6 @@ OUTPUT_SCHEMA_COLUMNS = [
     "geotype",
     "labs_geotype",
     "pff_variable",
-    "base_variable",
     "c",
     "e",
     "m",
@@ -127,11 +126,12 @@ def attach_base_variable(df, year):
         ["base_variable", "pff_variable"]
     ]
 
-    return df.merge(acs_variable_mapping, how="left", on="pff_variable")
+    return df.merge(acs_variable_mapping, how="inner", on="pff_variable")
 
 
 def rename_columns(df):
-    df.rename(columns={"geotype": "labs_geotype", "geoid": "labs_geoid"}, inplace=True)
+    df.rename(columns={"geotype": "labs_geotype",
+              "geoid": "labs_geoid"}, inplace=True)
     return df.reindex(columns=OUTPUT_SCHEMA_COLUMNS)
 
 

--- a/pipelines/acs_2020_manual_update.py
+++ b/pipelines/acs_2020_manual_update.py
@@ -11,6 +11,7 @@ OUTPUT_SCHEMA_COLUMNS = [
     "geotype",
     "labs_geotype",
     "pff_variable",
+    "base_variable",
     "c",
     "e",
     "m",
@@ -119,6 +120,16 @@ def transform_all_dataframes(year):
 
     return combined_df
 
+
+def attach_base_variable(df, year):
+    metadata_file = f"factfinder/data/acs/{year}/metadata.json"
+    acs_variable_mapping = pd.read_json(metadata_file)[
+        ["base_variable", "pff_variable"]
+    ]
+
+    return df.merge(acs_variable_mapping, how="left", on="pff_variable")
+
+
 def rename_columns(df):
     df.rename(columns={"geotype": "labs_geotype", "geoid": "labs_geoid"}, inplace=True)
     return df.reindex(columns=OUTPUT_SCHEMA_COLUMNS)
@@ -129,6 +140,7 @@ if __name__ == "__main__":
     year, geography = parse_args()
 
     export_df = transform_all_dataframes(year)
+    export_df = attach_base_variable(export_df, year)
     export_df = rename_columns(export_df)
 
     output_folder = f".output/acs/year={year}/geography={geography}"


### PR DESCRIPTION
Addresses #243 
This reverts commit ef50b5bbdda619bdf0be5884f1b5f981bb753021.

When we removed the base variable join from the script, we removed any respect for the metadata file for 2010, and just piped through the input excel file. The excel file has columns for variables not in the metadata file, causing issues for OSE. Adds an inner join on the metadata file so we can only return records with a matching metadata.

Needs 2 Reviewers