### PR TITLE
Update 2020 Metadata to add Base Variable for grpi20t24

### DIFF
--- a/factfinder/data/acs/2020/metadata.json
+++ b/factfinder/data/acs/2020/metadata.json
@@ -3819,7 +3819,7 @@
     },
     {
         "pff_variable": "grpi20t24",
-        "base_variable": "",
+        "base_variable": "ochuprnt2",
         "census_variable": [
             "DP04_0139"
         ],


### PR DESCRIPTION
Addresses #242 
Will need a 2nd PR for the 221-Aug Build Branch, but from my understanding OSE is pulling from the metadata on this branch directly