### PR TITLE
add manual update github action

### DIFF
--- a/.github/workflows/acs_manual_update.yml
+++ b/.github/workflows/acs_manual_update.yml
@@ -1,0 +1,52 @@
+name: Build - ACS Manual Update
+
+on:
+  workflow_dispatch:
+    inputs:
+      data_year:
+        description: 'Release year of ACS data. e.g. For 2016-2020 acs5 data, type "2020"'
+        required: true
+        default: '2020'
+      geo_year:
+        description: 'Year of geographic units. Options: "2010", "2020", or "2010_to_2020"'
+        required: true
+        default: '2010_to_2020'
+jobs:
+  build:
+    name: "ACS Manual Update Year: ${{ github.event.inputs.data_year }} Geography: ${{ github.event.inputs.geo_year }}"
+    env:
+      API_KEY: ${{ secrets.API_KEY }}
+      EDM_DATA: ${{ secrets.EDM_DATA }}
+      DATA_YEAR: ${{ github.event.inputs.data_year }}
+      GEO_YEAR: ${{ github.event.inputs.geo_year }}
+      AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Install Minio CLI
+        run: |
+          curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
+          chmod +x mc
+          sudo mv ./mc /usr/bin
+          mc config host add spaces $AWS_S3_ENDPOINT $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY --api S3v4
+
+      - name: Install locally
+        run: |
+          python3.9 -m pip install --upgrade pip
+          python3.9 -m pip install .
+
+      - name: run pipelines/acs
+        run: |
+          python3.9 -m pipelines.acs_manual_update --year $DATA_YEAR --geography $GEO_YEAR
+
+      - name: upload to s3
+        run: |
+          ACS_FILE_PATH=.output/acs/year=$DATA_YEAR/geography=$GEO_YEAR/acs_manual_update.csv
+          mc cp $ACS_FILE_PATH spaces/edm-publishing/db-factfinder/acs/year=$DATA_YEAR/geography=$GEO_YEAR/acs.csv


### PR DESCRIPTION
per ACS Update issue https://github.com/NYCPlanning/db-factfinder/issues/250 and in-progress PR #252 
- there's [an action from a dev branch](https://github.com/NYCPlanning/db-factfinder/actions/workflows/acs_2020_manual_update.yml) we'd like to use
- but we can't run it manually until it exists on the `main` branch
- this PR is just to add the action