### PR TITLE
fix 2021 metadata.json

### DIFF
--- a/factfinder/data/acs/2021/metadata.json
+++ b/factfinder/data/acs/2021/metadata.json
@@ -19,7 +19,8 @@
         "domain": "community_profiles",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgbase",
@@ -30,7 +31,8 @@
         "domain": "community_profiles",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "ownerocc",
@@ -41,7 +43,8 @@
         "domain": "community_profiles",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "occbaseunits",
@@ -52,7 +55,8 @@
         "domain": "community_profiles",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "owneroccbase",
@@ -63,7 +67,8 @@
         "domain": "community_profiles",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "mortg",
@@ -74,7 +79,8 @@
         "domain": "community_profiles",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "costburden",
@@ -92,7 +98,8 @@
         "domain": "community_profiles",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "renteroccbase",
@@ -103,7 +110,8 @@
         "domain": "community_profiles",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "rentburden",
@@ -117,7 +125,8 @@
         "domain": "community_profiles",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "f16pl",
@@ -128,7 +137,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "cvnipop2",
@@ -139,7 +149,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "nlf1",
@@ -150,7 +161,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "mft2p5t5",
@@ -161,7 +173,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdefftwrk",
@@ -172,7 +185,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Earnings"
     },
     {
         "pff_variable": "inc_cpba",
@@ -183,7 +197,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "wrkr16pl",
@@ -194,7 +209,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Commute to Work"
     },
     {
         "pff_variable": "prdtrnsmm",
@@ -205,7 +221,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Occupation"
     },
     {
         "pff_variable": "mdemftwrk",
@@ -216,7 +233,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Earnings"
     },
     {
         "pff_variable": "mdhhi30t34",
@@ -227,7 +245,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "empbhins",
@@ -238,7 +257,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "mft7p5t10",
@@ -249,7 +269,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "fftu2pt5k",
@@ -260,7 +281,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "pv175t184",
@@ -280,7 +302,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ratio of Income to Poverty Level"
     },
     {
         "pff_variable": "empvhins",
@@ -291,7 +314,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "mdhh",
@@ -302,7 +326,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "whlsale",
@@ -313,7 +338,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Industry"
     },
     {
         "pff_variable": "hi150t199",
@@ -324,7 +350,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "mf17p5t20",
@@ -335,7 +362,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdhi150t199",
@@ -346,7 +374,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "nfmi45t49",
@@ -357,7 +386,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdfami50t59",
@@ -368,7 +398,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "slfemninc",
@@ -379,7 +410,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Class of Worker"
     },
     {
         "pff_variable": "ff10t12p5",
@@ -390,7 +422,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mft5t7p5",
@@ -401,7 +434,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "nfmi30t34",
@@ -412,7 +446,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "salesoff",
@@ -423,7 +458,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Occupation"
     },
     {
         "pff_variable": "agip15pl",
@@ -434,7 +470,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdnfinc",
@@ -445,7 +482,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "mdfi150t199",
@@ -456,7 +494,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "emhins",
@@ -467,7 +506,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "hi100t149",
@@ -478,7 +518,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "fam2",
@@ -489,7 +530,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "ern50t55",
@@ -503,7 +545,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "retail",
@@ -514,7 +557,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Industry"
     },
     {
         "pff_variable": "pop_6",
@@ -525,7 +569,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "p65plbwpv",
@@ -536,7 +581,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income in Past 12 Months is Below the Poverty Level"
     },
     {
         "pff_variable": "p65plbwpv_pct",
@@ -547,7 +593,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "mntrvtm",
@@ -558,7 +605,8 @@
         "domain": "economic",
         "rounding": "1",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Commute to Work"
     },
     {
         "pff_variable": "ern75t100",
@@ -572,7 +620,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "updfmwrkr",
@@ -583,7 +632,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Class of Worker"
     },
     {
         "pff_variable": "nlfnhins",
@@ -594,7 +644,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "hh5",
@@ -605,7 +656,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "nlf2",
@@ -616,7 +668,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "fft40t45",
@@ -627,7 +680,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "pv200t299",
@@ -647,7 +701,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ratio of Income to Poverty Level"
     },
     {
         "pff_variable": "fft30t35",
@@ -658,7 +713,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "pu18bwpv",
@@ -669,7 +725,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income in Past 12 Months is Below the Poverty Level"
     },
     {
         "pff_variable": "pu18bwpv_pct",
@@ -680,7 +737,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "cvlfuem2",
@@ -691,7 +749,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "pv75t99",
@@ -711,7 +770,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ratio of Income to Poverty Level"
     },
     {
         "pff_variable": "pv150t174",
@@ -731,7 +791,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ratio of Income to Poverty Level"
     },
     {
         "pff_variable": "hhi25t34",
@@ -742,7 +803,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "hhi35t49",
@@ -753,7 +815,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "mdhi100t124",
@@ -764,7 +827,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mnfctrng",
@@ -775,7 +839,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Industry"
     },
     {
         "pff_variable": "hhiu10",
@@ -786,7 +851,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "pv185t199",
@@ -806,7 +872,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ratio of Income to Poverty Level"
     },
     {
         "pff_variable": "ern25t30",
@@ -820,7 +887,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "cvlfuem1",
@@ -831,7 +899,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "fami50t74",
@@ -842,7 +911,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "pv500pl",
@@ -862,7 +932,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ratio of Income to Poverty Level"
     },
     {
         "pff_variable": "fft55t65",
@@ -873,7 +944,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "cvlf2",
@@ -884,7 +956,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "mwrkern",
@@ -895,7 +968,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "fami200pl",
@@ -906,7 +980,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "fami25t34",
@@ -917,7 +992,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "nfam2",
@@ -928,7 +1004,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "pop16pl",
@@ -939,7 +1016,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "pbwpv",
@@ -950,7 +1028,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income in Past 12 Months is Below the Poverty Level"
     },
     {
         "pff_variable": "pbwpv_pct",
@@ -961,7 +1040,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "fft5t7p5",
@@ -972,7 +1052,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdhhi40t44",
@@ -983,7 +1064,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "e22pt5t25",
@@ -997,7 +1079,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mgbsciart",
@@ -1008,7 +1091,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Occupation"
     },
     {
         "pff_variable": "fft7p5t10",
@@ -1019,7 +1103,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "cw_wlkd",
@@ -1030,7 +1115,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Commute to Work"
     },
     {
         "pff_variable": "mdfami25t29",
@@ -1041,7 +1127,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "othnotpa",
@@ -1052,7 +1139,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Industry"
     },
     {
         "pff_variable": "mft40t45",
@@ -1063,7 +1151,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "pv125t149",
@@ -1083,7 +1172,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ratio of Income to Poverty Level"
     },
     {
         "pff_variable": "mdfami40t44",
@@ -1094,7 +1184,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "aghhinc",
@@ -1105,7 +1196,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "nfmi35t39",
@@ -1116,7 +1208,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "fft50t55",
@@ -1127,7 +1220,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdhhinc",
@@ -1138,7 +1232,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "nfmi20t24",
@@ -1149,7 +1244,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "wrkrnothm",
@@ -1161,7 +1257,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "info",
@@ -1172,7 +1269,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Industry"
     },
     {
         "pff_variable": "mft30t35",
@@ -1183,7 +1281,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "ff12p5t15",
@@ -1194,7 +1293,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "cvem16pl1",
@@ -1205,7 +1305,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "e10t12pt5",
@@ -1219,7 +1320,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "agffhm",
@@ -1230,7 +1332,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Industry"
     },
     {
         "pff_variable": "mdfi125t149",
@@ -1241,7 +1344,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdfaminc",
@@ -1252,7 +1356,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "mdhhi75t99",
@@ -1263,7 +1368,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "fft35t40",
@@ -1274,7 +1380,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "pvhins",
@@ -1285,7 +1392,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "fft75t100",
@@ -1296,7 +1404,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdhhi45t49",
@@ -1307,7 +1416,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "och6t17",
@@ -1318,7 +1428,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "fambwpv",
@@ -1329,7 +1440,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income in Past 12 Months is Below the Poverty Level"
     },
     {
         "pff_variable": "pbhins",
@@ -1340,7 +1452,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "poppvu1",
@@ -1351,7 +1464,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income in Past 12 Months is Below the Poverty Level"
     },
     {
         "pff_variable": "edhlthcsa",
@@ -1362,7 +1476,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Industry"
     },
     {
         "pff_variable": "ern35t40",
@@ -1376,7 +1491,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "cvniu18_2",
@@ -1387,7 +1503,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "pvu50",
@@ -1407,7 +1524,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ratio of Income to Poverty Level"
     },
     {
         "pff_variable": "ern30t35",
@@ -1421,7 +1539,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "nfmi10t14",
@@ -1432,7 +1551,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "hhi50t74",
@@ -1443,7 +1563,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "ff20t22p5",
@@ -1454,7 +1575,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "hhi10t14",
@@ -1465,7 +1587,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "famiu10",
@@ -1476,7 +1599,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "cw_pbtrns",
@@ -1487,7 +1611,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Commute to Work"
     },
     {
         "pff_variable": "hins",
@@ -1498,7 +1623,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "e20t22pt5",
@@ -1512,7 +1638,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "ff15t17p5",
@@ -1523,7 +1650,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdhhi25t29",
@@ -1534,7 +1662,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdfami75t99",
@@ -1545,7 +1674,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "f16plcvlf",
@@ -1556,7 +1686,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "ern45t50",
@@ -1570,7 +1701,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "cw_oth",
@@ -1581,7 +1713,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Commute to Work"
     },
     {
         "pff_variable": "mdhhiu10",
@@ -1592,7 +1725,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mftu2pt5k",
@@ -1603,7 +1737,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdhi125t149",
@@ -1614,7 +1749,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "uem",
@@ -1625,7 +1761,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "emnhins",
@@ -1636,7 +1773,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "ern2pt5t5",
@@ -1650,7 +1788,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "fft100pl",
@@ -1661,7 +1800,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "nfi200pl",
@@ -1672,7 +1812,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "nhins",
@@ -1683,7 +1824,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "oc6t17plf",
@@ -1694,7 +1836,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "nlfhins",
@@ -1705,7 +1848,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "fft25t30",
@@ -1716,7 +1860,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "e12pt5t15",
@@ -1730,7 +1875,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "hhi15t24",
@@ -1741,7 +1887,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "f16pllf",
@@ -1752,7 +1899,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "nf100t124",
@@ -1763,7 +1911,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "lf",
@@ -1774,7 +1923,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "ern5t7pt5",
@@ -1788,7 +1938,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "fami75t99",
@@ -1799,7 +1950,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "mdhhi50t59",
@@ -1810,7 +1962,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "gvtwrkr",
@@ -1821,7 +1974,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Class of Worker"
     },
     {
         "pff_variable": "mdhhi10t14",
@@ -1832,7 +1986,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdfi100t124",
@@ -1843,7 +1998,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "fi100t149",
@@ -1854,7 +2010,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "mft100pl",
@@ -1865,7 +2022,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "e15t17pt5",
@@ -1879,7 +2037,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "uempbhins",
@@ -1890,7 +2049,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "cw_drvaln",
@@ -1901,7 +2061,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Commute to Work"
     },
     {
         "pff_variable": "lfarmdf",
@@ -1912,7 +2073,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "nfmi60t74",
@@ -1923,7 +2085,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "ern100pl",
@@ -1937,7 +2100,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "ern65t75",
@@ -1951,7 +2115,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "inc_sosec",
@@ -1962,7 +2127,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "srvc",
@@ -1973,7 +2139,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Occupation"
     },
     {
         "pff_variable": "prfsmgawm",
@@ -1984,7 +2151,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Industry"
     },
     {
         "pff_variable": "inc_snap",
@@ -1995,7 +2163,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "e17pt5t20",
@@ -2009,7 +2178,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mnhhinc",
@@ -2020,7 +2190,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "fft65t75",
@@ -2031,7 +2202,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "ernu2pt5k",
@@ -2045,7 +2217,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "nfam",
@@ -2056,7 +2229,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "fami15t24",
@@ -2067,7 +2241,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "uemnhins",
@@ -2078,7 +2253,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "mdfamiu10",
@@ -2089,7 +2265,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "p65plpvu",
@@ -2100,7 +2277,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income in Past 12 Months is Below the Poverty Level"
     },
     {
         "pff_variable": "nf150t199",
@@ -2111,7 +2289,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mf20t22p5",
@@ -2122,7 +2301,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "fwrkern",
@@ -2133,7 +2313,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "inc_spsec",
@@ -2144,7 +2325,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "mft45t50",
@@ -2155,7 +2337,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "pv100t124",
@@ -2175,7 +2358,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ratio of Income to Poverty Level"
     },
     {
         "pff_variable": "mdhhi20t24",
@@ -2186,7 +2370,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "agttm",
@@ -2197,7 +2382,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "ochu6",
@@ -2208,7 +2394,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "ern40t45",
@@ -2222,7 +2409,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "pv400t499",
@@ -2242,7 +2430,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ratio of Income to Poverty Level"
     },
     {
         "pff_variable": "prvwswrkr",
@@ -2253,7 +2442,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Class of Worker"
     },
     {
         "pff_variable": "mft75t100",
@@ -2264,7 +2454,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "fi150t199",
@@ -2275,7 +2466,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "cvem16pl4",
@@ -2286,7 +2478,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Class of Worker"
     },
     {
         "pff_variable": "hh2",
@@ -2297,7 +2490,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "cw_crpld",
@@ -2308,7 +2502,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Commute to Work"
     },
     {
         "pff_variable": "mft55t65",
@@ -2319,7 +2514,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "u18nhins",
@@ -2330,7 +2526,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "fami10t14",
@@ -2341,7 +2538,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "nfmiu10",
@@ -2352,7 +2550,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdhhi15t19",
@@ -2363,7 +2562,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "fire",
@@ -2374,7 +2574,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Industry"
     },
     {
         "pff_variable": "mdhhi60t74",
@@ -2385,7 +2586,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mft65t75",
@@ -2396,7 +2598,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "percapinc",
@@ -2407,7 +2610,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "uempvhins",
@@ -2418,7 +2622,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "mft25t30",
@@ -2429,7 +2634,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdfami60t74",
@@ -2440,7 +2646,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "fami35t49",
@@ -2451,7 +2658,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "fampvu",
@@ -2462,7 +2670,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income in Past 12 Months is Below the Poverty Level"
     },
     {
         "pff_variable": "f16plclfe",
@@ -2473,7 +2682,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "mdfami15t19",
@@ -2484,7 +2694,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "constctn",
@@ -2495,7 +2706,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Industry"
     },
     {
         "pff_variable": "mdfami10t14",
@@ -2506,7 +2718,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mft35t40",
@@ -2517,7 +2730,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdfami20t24",
@@ -2528,7 +2742,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdhhi200pl",
@@ -2539,7 +2754,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "poppvu2",
@@ -2550,7 +2766,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ratio of Income to Poverty Level"
     },
     {
         "pff_variable": "cvem16pl3",
@@ -2561,7 +2778,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Industry"
     },
     {
         "pff_variable": "mf12p5t15",
@@ -2572,7 +2790,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "nfmi15t19",
@@ -2583,7 +2802,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "pu18pvu",
@@ -2594,7 +2814,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income in Past 12 Months is Below the Poverty Level"
     },
     {
         "pff_variable": "nrcnstmnt",
@@ -2605,7 +2826,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Occupation"
     },
     {
         "pff_variable": "cvlfem",
@@ -2616,7 +2838,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "ff17p5t20",
@@ -2627,7 +2850,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "wrke16pl",
@@ -2641,7 +2865,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "artenrafs",
@@ -2652,7 +2877,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Industry"
     },
     {
         "pff_variable": "mf15t17p5",
@@ -2663,7 +2889,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "fft2p5t5",
@@ -2674,7 +2901,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "cw_wrkdhm",
@@ -2685,7 +2913,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Commute to Work"
     },
     {
         "pff_variable": "nlfpbhins",
@@ -2696,7 +2925,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "uemhins",
@@ -2707,7 +2937,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "trwhut",
@@ -2718,7 +2949,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Industry"
     },
     {
         "pff_variable": "cni1864_2",
@@ -2729,7 +2961,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "mdhhi35t39",
@@ -2740,7 +2973,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mf22p5t25",
@@ -2751,7 +2985,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "nfmi50t59",
@@ -2762,7 +2997,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "nlfpvhins",
@@ -2773,7 +3009,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "hhi200pl",
@@ -2784,7 +3021,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "hhi75t99",
@@ -2795,7 +3033,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "mf10t12p5",
@@ -2806,7 +3045,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "cvem16pl2",
@@ -2817,7 +3057,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Occupation"
     },
     {
         "pff_variable": "pv300t399",
@@ -2837,7 +3078,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ratio of Income to Poverty Level"
     },
     {
         "pff_variable": "fft45t50",
@@ -2848,7 +3090,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "nf125t149",
@@ -2859,7 +3102,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "ochu6plf",
@@ -2870,7 +3114,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "cvlf18t64",
@@ -2881,7 +3126,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Health Insurance Coverage"
     },
     {
         "pff_variable": "mft50t55",
@@ -2892,7 +3138,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "nfmi75t99",
@@ -2903,7 +3150,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "pv50t74",
@@ -2923,7 +3171,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ratio of Income to Poverty Level"
     },
     {
         "pff_variable": "mdewrk",
@@ -2934,7 +3183,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Earnings"
     },
     {
         "pff_variable": "mdfam",
@@ -2945,7 +3195,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdfami30t34",
@@ -2956,7 +3207,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "nfmi40t44",
@@ -2967,7 +3219,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "ff22p5t25",
@@ -2978,7 +3231,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "inc_rtrmt",
@@ -2989,7 +3243,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Income and Benefits"
     },
     {
         "pff_variable": "e7pt5t10",
@@ -3003,7 +3258,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "cvlf1",
@@ -3014,7 +3270,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Employment Status"
     },
     {
         "pff_variable": "mdfami35t39",
@@ -3025,7 +3282,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdfami45t49",
@@ -3036,7 +3294,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "ern55t65",
@@ -3050,7 +3309,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "pubadmin",
@@ -3061,7 +3321,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Industry"
     },
     {
         "pff_variable": "nfmi25t29",
@@ -3072,7 +3333,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "mdfami200pl",
@@ -3083,7 +3345,8 @@
         "domain": "economic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Economic- Special Variable"
     },
     {
         "pff_variable": "vhcl1av",
@@ -3094,7 +3357,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Vehicles Available"
     },
     {
         "pff_variable": "ochu4",
@@ -3105,7 +3369,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Vehicles Available"
     },
     {
         "pff_variable": "hu3",
@@ -3116,7 +3381,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year Structure Built"
     },
     {
         "pff_variable": "blt50t59",
@@ -3127,7 +3393,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year Structure Built"
     },
     {
         "pff_variable": "ovl40t49",
@@ -3138,7 +3405,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "r400t449",
@@ -3149,7 +3417,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "popoochu",
@@ -3160,7 +3429,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "btrvvetc",
@@ -3171,7 +3441,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Units in Structure"
     },
     {
         "pff_variable": "r600t649",
@@ -3182,7 +3453,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "r800t899",
@@ -3193,7 +3465,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "gr15kt19k",
@@ -3204,7 +3477,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent"
     },
     {
         "pff_variable": "rochu2",
@@ -3215,7 +3489,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "r1p5t1999",
@@ -3226,7 +3501,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "blt00t09",
@@ -3237,7 +3513,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year Structure Built"
     },
     {
         "pff_variable": "grpiu15",
@@ -3248,7 +3525,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent as a Percentage of Household Income (GRAPI)"
     },
     {
         "pff_variable": "ov250t299",
@@ -3259,7 +3537,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "hu1",
@@ -3270,7 +3549,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing Occupancy"
     },
     {
         "pff_variable": "ochu5",
@@ -3281,7 +3561,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Occupants Per Room"
     },
     {
         "pff_variable": "novhclav",
@@ -3292,7 +3573,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Vehicles Available"
     },
     {
         "pff_variable": "hu5t9u",
@@ -3303,7 +3585,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Units in Structure"
     },
     {
         "pff_variable": "mdrms",
@@ -3314,7 +3597,8 @@
         "domain": "housing",
         "rounding": "1",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Rooms"
     },
     {
         "pff_variable": "grpi35pl",
@@ -3325,7 +3609,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "ovl30t34",
@@ -3336,7 +3621,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "blt10ltr",
@@ -3348,7 +3634,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": "Year Structure Built fields DP04_0017 & DP04_0018 have changed from \"Built 2010 to 2013\" and \"Built 2014 or later\" to \"Built 2010 to 2019\" and \"Built 2020 or later\" "
+        "Notes": "Year Structure Built fields DP04_0017 & DP04_0018 have changed from \"Built 2010 to 2013\" and \"Built 2014 or later\" to \"Built 2010 to 2019\" and \"Built 2020 or later\" ",
+        "category": "Year Structure Built"
     },
     {
         "pff_variable": "r750t799",
@@ -3359,7 +3646,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "ovl50t59",
@@ -3370,7 +3658,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "nmsmpntc",
@@ -3381,7 +3670,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "vacsoldno",
@@ -3392,7 +3682,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "rms2",
@@ -3403,7 +3694,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Rooms"
     },
     {
         "pff_variable": "blt60t69",
@@ -3414,7 +3706,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year Structure Built"
     },
     {
         "pff_variable": "r2kt2499",
@@ -3425,7 +3718,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "r700t749",
@@ -3436,7 +3730,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "ovl60t69",
@@ -3447,7 +3742,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "vachu",
@@ -3458,7 +3754,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing Occupancy"
     },
     {
         "pff_variable": "hunomrtg1",
@@ -3469,7 +3766,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Mortgage Status"
     },
     {
         "pff_variable": "hovacu",
@@ -3482,7 +3780,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "r500t549",
@@ -3493,7 +3792,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "ochu1",
@@ -3504,7 +3804,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing Occupancy"
     },
     {
         "pff_variable": "hu1ud",
@@ -3515,7 +3816,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Units in Structure"
     },
     {
         "pff_variable": "nmsmpu10",
@@ -3526,7 +3828,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "grpi30t34",
@@ -3537,7 +3840,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "rntvacu",
@@ -3550,7 +3854,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "mv10ltr",
@@ -3562,7 +3867,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year Householder Moved Into Unit"
     },
     {
         "pff_variable": "r250t299",
@@ -3573,7 +3879,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "huwmrtg",
@@ -3584,7 +3891,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Mortgage Status"
     },
     {
         "pff_variable": "r900t999",
@@ -3595,7 +3903,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "ovl15t19",
@@ -3606,7 +3915,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "hu4",
@@ -3617,7 +3927,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Rooms"
     },
     {
         "pff_variable": "oochu2",
@@ -3628,7 +3939,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Value"
     },
     {
         "pff_variable": "nmsmp2529",
@@ -3639,7 +3951,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "r350t399",
@@ -3650,7 +3963,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "nmsmp3034",
@@ -3661,7 +3975,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "rms3",
@@ -3672,7 +3987,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Rooms"
     },
     {
         "pff_variable": "r1250t1p5",
@@ -3683,7 +3999,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "r3500pl",
@@ -3694,7 +4011,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "ov2milpl",
@@ -3705,7 +4023,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "vacrnt",
@@ -3716,7 +4035,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "vl1milpl",
@@ -3727,7 +4047,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Value"
     },
     {
         "pff_variable": "r200t249",
@@ -3738,7 +4059,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "r1kt1249",
@@ -3749,7 +4071,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "ovl90t99",
@@ -3760,7 +4083,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "mdgr",
@@ -3771,7 +4095,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent"
     },
     {
         "pff_variable": "ov175t199",
@@ -3782,7 +4107,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "mvbf89",
@@ -3793,7 +4119,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year Householder Moved Into Unit"
     },
     {
         "pff_variable": "ov125t149",
@@ -3804,7 +4131,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "vl500t999",
@@ -3815,7 +4143,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Value"
     },
     {
         "pff_variable": "ovl25t29",
@@ -3826,7 +4155,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "hovacrt",
@@ -3837,7 +4167,8 @@
         "domain": "housing",
         "rounding": "1",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing Occupancy"
     },
     {
         "pff_variable": "rochu1",
@@ -3848,7 +4179,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing Tenure"
     },
     {
         "pff_variable": "ochu3",
@@ -3859,7 +4191,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year Householder Moved Into Unit"
     },
     {
         "pff_variable": "vl150t199",
@@ -3870,7 +4203,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Value"
     },
     {
         "pff_variable": "hu10t19u",
@@ -3881,7 +4215,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Units in Structure"
     },
     {
         "pff_variable": "vl50t99",
@@ -3892,7 +4227,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Value"
     },
     {
         "pff_variable": "nmsmp1014",
@@ -3903,7 +4239,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "ov400t499",
@@ -3914,7 +4251,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "vhcl3plav",
@@ -3925,7 +4263,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Vehicles Available"
     },
     {
         "pff_variable": "huwmrtgex",
@@ -3936,7 +4275,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "ru100",
@@ -3947,7 +4287,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "blt80t89",
@@ -3958,7 +4299,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year Structure Built"
     },
     {
         "pff_variable": "ochuprnt1",
@@ -3969,7 +4311,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent"
     },
     {
         "pff_variable": "gr20kt24k",
@@ -3980,7 +4323,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent"
     },
     {
         "pff_variable": "vacsale",
@@ -3991,7 +4335,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "gr25kt29k",
@@ -4002,7 +4347,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent"
     },
     {
         "pff_variable": "r2p5t2999",
@@ -4013,7 +4359,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "hu2",
@@ -4024,7 +4371,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Units in Structure"
     },
     {
         "pff_variable": "vl200t299",
@@ -4035,7 +4383,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Value"
     },
     {
         "pff_variable": "ovl80t89",
@@ -4046,7 +4395,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "ovlu10",
@@ -4057,7 +4407,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "vl100t149",
@@ -4068,7 +4419,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Value"
     },
     {
         "pff_variable": "ov750t999",
@@ -4079,7 +4431,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "vacrntno",
@@ -4090,7 +4443,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "r150t199",
@@ -4101,7 +4455,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "hu3t4u",
@@ -4112,7 +4467,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Units in Structure"
     },
     {
         "pff_variable": "smp25t29",
@@ -4123,7 +4479,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "hu20plu",
@@ -4134,7 +4491,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Units in Structure"
     },
     {
         "pff_variable": "vhcl2av",
@@ -4145,7 +4503,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Vehicles Available"
     },
     {
         "pff_variable": "ov500t749",
@@ -4156,7 +4515,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "gr500t999",
@@ -4167,7 +4527,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent"
     },
     {
         "pff_variable": "nmsmp35pl",
@@ -4178,7 +4539,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "r3kt3499",
@@ -4189,7 +4551,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "ov1t149m",
@@ -4200,7 +4563,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "grpi20t24",
@@ -4211,7 +4575,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent as a Percentage of Household Income (GRAPI)"
     },
     {
         "pff_variable": "smpu20",
@@ -4222,7 +4587,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "rms6",
@@ -4233,7 +4599,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Rooms"
     },
     {
         "pff_variable": "ochuprnt2",
@@ -4244,7 +4611,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent as a Percentage of Household Income (GRAPI)"
     },
     {
         "pff_variable": "blt90t99",
@@ -4255,7 +4623,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year Structure Built"
     },
     {
         "pff_variable": "grpintc",
@@ -4266,7 +4635,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent as a Percentage of Household Income (GRAPI)"
     },
     {
         "pff_variable": "ochu2",
@@ -4277,7 +4647,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing Tenure"
     },
     {
         "pff_variable": "ov300t399",
@@ -4288,7 +4659,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "mobhm",
@@ -4299,7 +4671,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Units in Structure"
     },
     {
         "pff_variable": "oochu1",
@@ -4310,7 +4683,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing Tenure"
     },
     {
         "pff_variable": "mdvl",
@@ -4321,7 +4695,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Value"
     },
     {
         "pff_variable": "r300t349",
@@ -4332,7 +4707,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "rms1",
@@ -4343,7 +4719,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Rooms"
     },
     {
         "pff_variable": "rms4",
@@ -4354,7 +4731,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Rooms"
     },
     {
         "pff_variable": "smp35pl",
@@ -4365,7 +4743,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "grpi25t29",
@@ -4376,7 +4755,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent as a Percentage of Household Income (GRAPI)"
     },
     {
         "pff_variable": "ovl20t24",
@@ -4387,7 +4767,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "grnorntpd",
@@ -4398,7 +4779,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent"
     },
     {
         "pff_variable": "oochu3",
@@ -4409,7 +4791,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Mortgage Status"
     },
     {
         "pff_variable": "smp30t34",
@@ -4420,7 +4803,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "oochu5",
@@ -4431,7 +4815,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "rms9pl",
@@ -4442,7 +4827,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Rooms"
     },
     {
         "pff_variable": "blt70t79",
@@ -4453,7 +4839,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year Structure Built"
     },
     {
         "pff_variable": "avghhsroc",
@@ -4464,7 +4851,8 @@
         "domain": "housing",
         "rounding": "2",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing Tenure"
     },
     {
         "pff_variable": "oochu4",
@@ -4475,7 +4863,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "ocpr1pl",
@@ -4487,7 +4876,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Occupants Per Room"
     },
     {
         "pff_variable": "nmsmp1519",
@@ -4498,7 +4888,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "r650t699",
@@ -4509,7 +4900,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "ocpr1p5pl",
@@ -4520,7 +4912,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Occupants Per Room"
     },
     {
         "pff_variable": "smp20t24",
@@ -4531,7 +4924,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "ov150t174",
@@ -4542,7 +4936,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "bltbf39",
@@ -4553,7 +4948,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year Structure Built"
     },
     {
         "pff_variable": "rms5",
@@ -4564,7 +4960,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Rooms"
     },
     {
         "pff_variable": "gru500",
@@ -4575,7 +4972,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent"
     },
     {
         "pff_variable": "gr1kt14k",
@@ -4586,7 +4984,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent"
     },
     {
         "pff_variable": "nmsmp2024",
@@ -4597,7 +4996,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "ovl70t79",
@@ -4608,7 +5008,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "ov100t124",
@@ -4619,7 +5020,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "ovl10t14",
@@ -4630,7 +5032,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "hu2u",
@@ -4641,7 +5044,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Units in Structure"
     },
     {
         "pff_variable": "ovl35t39",
@@ -4652,7 +5056,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "rms7",
@@ -4663,7 +5068,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Rooms"
     },
     {
         "pff_variable": "r550t599",
@@ -4674,7 +5080,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "ov150t199m",
@@ -4685,7 +5092,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "grpi50pl",
@@ -4696,7 +5104,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent as a Percentage of Household Income (GRAPI)"
     },
     {
         "pff_variable": "grpi15t19",
@@ -4707,7 +5116,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent as a Percentage of Household Income (GRAPI)"
     },
     {
         "pff_variable": "r100t149",
@@ -4718,7 +5128,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "vl300t499",
@@ -4729,7 +5140,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Value"
     },
     {
         "pff_variable": "hunomrtg2",
@@ -4740,7 +5152,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "ocpr0t1",
@@ -4751,7 +5164,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Occupants Per Room"
     },
     {
         "pff_variable": "gr3kpl",
@@ -4762,7 +5176,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent"
     },
     {
         "pff_variable": "avghhsooc",
@@ -4773,7 +5188,8 @@
         "domain": "housing",
         "rounding": "2",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing Tenure"
     },
     {
         "pff_variable": "mv90t99",
@@ -4784,7 +5200,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year Householder Moved Into Unit"
     },
     {
         "pff_variable": "vlu50",
@@ -4795,7 +5212,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Value"
     },
     {
         "pff_variable": "roccshrnt",
@@ -4806,7 +5224,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "poprtochu",
@@ -4817,7 +5236,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "mv00t09",
@@ -4828,7 +5248,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year Householder Moved Into Unit"
     },
     {
         "pff_variable": "hu1ua",
@@ -4839,7 +5260,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Units in Structure"
     },
     {
         "pff_variable": "blt40t49",
@@ -4850,7 +5272,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year Structure Built"
     },
     {
         "pff_variable": "r450t499",
@@ -4861,7 +5284,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "smpntc",
@@ -4872,7 +5296,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Selected Monthly Owner Costs as a Percentage of Household Income (SMOCAPI)"
     },
     {
         "pff_variable": "rntvacrt",
@@ -4883,7 +5308,8 @@
         "domain": "housing",
         "rounding": "1",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing Occupancy"
     },
     {
         "pff_variable": "rms8",
@@ -4894,7 +5320,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Rooms"
     },
     {
         "pff_variable": "ov200t249",
@@ -4905,7 +5332,8 @@
         "domain": "housing",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Housing- Special Variable"
     },
     {
         "pff_variable": "cvnid_hrg",
@@ -4916,7 +5344,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "ea_grdpfd",
@@ -4927,7 +5356,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Educational Attainment (Highest Grade Completed)"
     },
     {
         "pff_variable": "eur",
@@ -4938,7 +5368,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "c65pldvsn",
@@ -4949,7 +5380,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "neur",
@@ -4960,7 +5392,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ireland",
@@ -4971,7 +5404,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ms_fnvmrd",
@@ -4982,7 +5416,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Marital Status"
     },
     {
         "pff_variable": "denmark",
@@ -4993,7 +5428,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "neurpn",
@@ -5004,7 +5440,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "alsatn",
@@ -5015,7 +5452,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "norway",
@@ -5026,7 +5464,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ea_hscgrd",
@@ -5037,7 +5476,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Educational Attainment (Highest Grade Completed)"
     },
     {
         "pff_variable": "sweden",
@@ -5048,7 +5488,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "untdkgdm",
@@ -5059,7 +5500,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "uknoengsc",
@@ -5070,7 +5512,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ghanaian",
@@ -5081,7 +5524,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "eng",
@@ -5092,7 +5536,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "european",
@@ -5103,7 +5548,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "scot",
@@ -5114,7 +5560,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "dhdfcntnyc",
@@ -5125,7 +5572,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Residence 1 Year Ago"
     },
     {
         "pff_variable": "lthian",
@@ -5136,7 +5584,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "oneur",
@@ -5147,7 +5596,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "weur",
@@ -5158,7 +5608,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "austria",
@@ -5169,7 +5620,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "jrdnian",
@@ -5180,7 +5632,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "israeli",
@@ -5191,7 +5644,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "belgium",
@@ -5202,7 +5656,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ms_fmrdsp",
@@ -5213,7 +5668,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Marital Status"
     },
     {
         "pff_variable": "english",
@@ -5224,7 +5680,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "cvnid_cog",
@@ -5235,7 +5692,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "rshp_sp",
@@ -5246,7 +5704,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Relationship to Head of Household (Householder)"
     },
     {
         "pff_variable": "ethpian",
@@ -5257,7 +5716,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "cu18dvsn",
@@ -5268,7 +5728,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "cvvet18pl",
@@ -5279,7 +5740,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Veteran Status"
     },
     {
         "pff_variable": "liberian",
@@ -5290,7 +5752,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "smhs",
@@ -5301,7 +5764,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Residence 1 Year Ago"
     },
     {
         "pff_variable": "german",
@@ -5312,7 +5776,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "france",
@@ -5323,7 +5788,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ms_fsp",
@@ -5334,7 +5800,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Marital Status"
     },
     {
         "pff_variable": "germany",
@@ -5345,7 +5812,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "zmbwean",
@@ -5356,7 +5824,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "nthrlds",
@@ -5367,7 +5836,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "sudanese",
@@ -5378,7 +5848,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "somali",
@@ -5389,7 +5860,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "switzrld",
@@ -5400,7 +5872,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "pop_4",
@@ -5411,7 +5884,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "oweur",
@@ -5422,7 +5896,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "osubsafr",
@@ -5433,7 +5908,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "seur",
@@ -5444,7 +5920,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "greece",
@@ -5455,7 +5932,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "italy",
@@ -5466,7 +5944,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ms_mnvmrd",
@@ -5477,7 +5956,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Marital Status"
     },
     {
         "pff_variable": "portugal",
@@ -5488,7 +5968,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "spain",
@@ -5499,7 +5980,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "oseur",
@@ -5510,7 +5992,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "eeur",
@@ -5521,7 +6004,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "avgfmsz",
@@ -5532,7 +6016,8 @@
         "domain": "social",
         "rounding": "2",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "ms_msp",
@@ -5543,7 +6028,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Marital Status"
     },
     {
         "pff_variable": "ntvus",
@@ -5554,7 +6040,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "nzealnd",
@@ -5565,7 +6052,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "czechslv",
@@ -5576,7 +6064,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "albania",
@@ -5587,7 +6076,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "belarus",
@@ -5598,7 +6088,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "belizean",
@@ -5609,7 +6100,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "unclsnr",
@@ -5620,7 +6112,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "hhcomp",
@@ -5631,7 +6124,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Computers and Internet Use"
     },
     {
         "pff_variable": "bosniah",
@@ -5642,7 +6136,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "se_g1t8",
@@ -5653,7 +6148,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "School Enrollment"
     },
     {
         "pff_variable": "croatian",
@@ -5664,7 +6160,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "windsub",
@@ -5675,7 +6172,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "bulgaria",
@@ -5686,7 +6184,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "croatia",
@@ -5697,7 +6196,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "c1864damb",
@@ -5708,7 +6208,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "czchslv",
@@ -5719,7 +6220,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "hungary",
@@ -5730,7 +6232,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "rshp_ssup",
@@ -5741,7 +6244,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Relationship to Head of Household (Householder)"
     },
     {
         "pff_variable": "fbntlzd",
@@ -5752,7 +6256,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "U.S. Citizenship Status"
     },
     {
         "pff_variable": "ms_f15pl",
@@ -5763,7 +6268,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Marital Status"
     },
     {
         "pff_variable": "frcandian",
@@ -5774,7 +6280,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "c65pldhrg",
@@ -5785,7 +6292,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "latvia",
@@ -5796,7 +6304,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "slovak",
@@ -5807,7 +6316,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "lthuania",
@@ -5818,7 +6328,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "mcdonia",
@@ -5829,7 +6340,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ea_ascd",
@@ -5840,7 +6352,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Educational Attainment (Highest Grade Completed)"
     },
     {
         "pff_variable": "portgese",
@@ -5851,7 +6364,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "dchwind",
@@ -5862,7 +6376,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "moldova",
@@ -5873,7 +6388,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "poland",
@@ -5884,7 +6400,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ntv",
@@ -5895,7 +6412,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "romania",
@@ -5906,7 +6424,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "cu18dcog",
@@ -5917,7 +6436,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "russia",
@@ -5928,7 +6448,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "austrln",
@@ -5939,7 +6460,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "hh1pl65pl",
@@ -5950,7 +6472,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "serbia",
@@ -5961,7 +6484,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ukraine",
@@ -5972,7 +6496,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "oeeur",
@@ -5983,7 +6508,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "eurnec",
@@ -5994,7 +6520,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "asia",
@@ -6005,7 +6532,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "easia",
@@ -6016,7 +6544,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "fam1",
@@ -6027,7 +6556,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "finnish",
@@ -6038,7 +6568,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "china",
@@ -6049,7 +6580,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "chnohktwn",
@@ -6060,7 +6592,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "tandtob",
@@ -6071,7 +6604,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "cvnipop1",
@@ -6082,7 +6616,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "hongkong",
@@ -6093,7 +6628,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "taiwan",
@@ -6104,7 +6640,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "mrdfam",
@@ -6115,7 +6652,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "japan",
@@ -6126,7 +6664,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "korea",
@@ -6137,7 +6676,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "serbian",
@@ -6148,7 +6688,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "ntvnys",
@@ -6159,7 +6700,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "avghhsz",
@@ -6170,7 +6712,8 @@
         "domain": "social",
         "rounding": "2",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "ntvnotnys",
@@ -6181,7 +6724,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "nfama",
@@ -6192,7 +6736,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "cu18dscr",
@@ -6203,7 +6748,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "cvrdean",
@@ -6214,7 +6760,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "bulgrian",
@@ -6225,7 +6772,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "rshp_nrup",
@@ -6236,7 +6784,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Relationship to Head of Household (Householder)"
     },
     {
         "pff_variable": "oeasia",
@@ -6247,7 +6796,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "abroad",
@@ -6258,7 +6808,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Residence 1 Year Ago"
     },
     {
         "pff_variable": "scasia",
@@ -6269,7 +6820,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "luxmbgr",
@@ -6280,7 +6832,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "usvrgis",
@@ -6291,7 +6844,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "cypriot",
@@ -6302,7 +6856,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "afghan",
@@ -6313,7 +6868,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "sctchirsh",
@@ -6324,7 +6880,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "c1864dvsn",
@@ -6335,7 +6892,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "c1864dscr",
@@ -6346,7 +6904,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "bngldsh",
@@ -6357,7 +6916,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "svtunion",
@@ -6368,7 +6928,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "asyrchlds",
@@ -6379,7 +6940,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "india",
@@ -6390,7 +6952,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "rshp_ch",
@@ -6401,7 +6964,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Relationship to Head of Household (Householder)"
     },
     {
         "pff_variable": "brzlian",
@@ -6412,7 +6976,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "iran",
@@ -6423,7 +6988,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "egyptn",
@@ -6434,7 +7000,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "yugoslv",
@@ -6445,7 +7012,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "irish",
@@ -6456,7 +7024,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "dfhsdfcnt",
@@ -6467,7 +7036,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Residence 1 Year Ago"
     },
     {
         "pff_variable": "czech",
@@ -6478,7 +7048,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "kzkhstan",
@@ -6489,7 +7060,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "nepal",
@@ -6500,7 +7072,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "pakistan",
@@ -6511,7 +7084,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "brtwind",
@@ -6522,7 +7096,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "ea_sclgnd",
@@ -6533,7 +7108,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Educational Attainment (Highest Grade Completed)"
     },
     {
         "pff_variable": "brbdian",
@@ -6544,7 +7120,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "srilanka",
@@ -6555,7 +7132,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "uzbkstan",
@@ -6566,7 +7144,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "oscasia",
@@ -6577,7 +7156,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "cvnid_vsn",
@@ -6588,7 +7168,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "dfhs2",
@@ -6599,7 +7180,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Residence 1 Year Ago"
     },
     {
         "pff_variable": "seasia",
@@ -6610,7 +7192,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "greek",
@@ -6621,7 +7204,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "burma",
@@ -6632,7 +7216,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "cambodia",
@@ -6643,7 +7228,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "indnsia",
@@ -6654,7 +7240,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "laos",
@@ -6665,7 +7252,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "malaysia",
@@ -6676,7 +7264,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "philipns",
@@ -6687,7 +7276,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ms_fwd",
@@ -6698,7 +7288,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Marital Status"
     },
     {
         "pff_variable": "cvniu18d",
@@ -6709,7 +7300,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "c1864dhrg",
@@ -6720,7 +7312,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "sngapore",
@@ -6731,7 +7324,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "cvniu18_1",
@@ -6742,7 +7336,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "sleonean",
@@ -6753,7 +7348,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "romanian",
@@ -6764,7 +7360,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "thailand",
@@ -6775,7 +7372,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "vietnam",
@@ -6786,7 +7384,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "rshp_nr",
@@ -6797,7 +7396,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Relationship to Head of Household (Householder)"
     },
     {
         "pff_variable": "alb",
@@ -6808,7 +7408,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "hh1",
@@ -6819,7 +7420,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "oseasia",
@@ -6830,7 +7432,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "amercn",
@@ -6841,7 +7444,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "wasia",
@@ -6852,7 +7456,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "armenia",
@@ -6863,7 +7468,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "macdnian",
@@ -6874,7 +7480,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "oarab",
@@ -6885,7 +7492,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "germrus",
@@ -6896,7 +7504,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "ea_p25pl",
@@ -6907,7 +7516,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Educational Attainment (Highest Grade Completed)"
     },
     {
         "pff_variable": "iraq",
@@ -6918,7 +7528,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "cni18t64d",
@@ -6929,7 +7540,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "israel",
@@ -6940,7 +7552,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "gplgcu18",
@@ -6951,7 +7564,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Grandparents"
     },
     {
         "pff_variable": "jordan",
@@ -6962,7 +7576,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "nfam1",
@@ -6973,7 +7588,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "polish",
@@ -6984,7 +7600,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "eeurpn",
@@ -6995,7 +7612,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "kuwait",
@@ -7006,7 +7624,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ea_bchdh",
@@ -7017,7 +7636,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Educational Attainment (Highest Grade Completed)"
     },
     {
         "pff_variable": "c65pldild",
@@ -7028,7 +7648,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "lebanon",
@@ -7039,7 +7660,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "dfhs1",
@@ -7050,7 +7672,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Residence 1 Year Ago"
     },
     {
         "pff_variable": "belgian",
@@ -7061,7 +7684,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "fbnotczn",
@@ -7072,7 +7696,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "U.S. Citizenship Status"
     },
     {
         "pff_variable": "arabsub",
@@ -7083,7 +7708,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "saudiar",
@@ -7094,7 +7720,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "syria",
@@ -7105,7 +7732,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "turkey",
@@ -7116,7 +7744,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "hhpop",
@@ -7127,7 +7756,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Relationship to Head of Household (Householder)"
     },
     {
         "pff_variable": "cvni65pld",
@@ -7138,7 +7768,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "dfhsus",
@@ -7149,7 +7780,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Residence 1 Year Ago"
     },
     {
         "pff_variable": "yemen",
@@ -7160,7 +7792,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "owasia",
@@ -7171,7 +7804,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "asianec",
@@ -7182,7 +7816,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "afr",
@@ -7193,7 +7828,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "eafr",
@@ -7204,7 +7840,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "eritrea",
@@ -7215,7 +7852,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ethiopia",
@@ -7226,7 +7864,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "kenya",
@@ -7237,7 +7876,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "arab",
@@ -7248,7 +7888,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "oeafr",
@@ -7262,7 +7903,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "mafr",
@@ -7273,7 +7915,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "maltese",
@@ -7284,7 +7927,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "cameroon",
@@ -7295,7 +7939,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "swiss",
@@ -7306,7 +7951,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "ugandan",
@@ -7317,7 +7963,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "dfhssmcnt",
@@ -7328,7 +7975,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Residence 1 Year Ago"
     },
     {
         "pff_variable": "omafr",
@@ -7341,7 +7989,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "nafr",
@@ -7352,7 +8001,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "egypt",
@@ -7363,7 +8013,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "mrdchu18",
@@ -7374,7 +8025,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "kenyan",
@@ -7385,7 +8037,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "moroccan",
@@ -7396,7 +8049,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "morocco",
@@ -7407,7 +8061,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "iraqi",
@@ -7418,7 +8073,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "sudan",
@@ -7429,7 +8085,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ea_bchd",
@@ -7440,7 +8097,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Educational Attainment (Highest Grade Completed)"
     },
     {
         "pff_variable": "cni1864_1",
@@ -7451,7 +8109,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "onafr",
@@ -7462,7 +8121,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "guyanese",
@@ -7473,7 +8133,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "ea_9t12nd",
@@ -7484,7 +8145,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Educational Attainment (Highest Grade Completed)"
     },
     {
         "pff_variable": "sthrnafr",
@@ -7495,7 +8157,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "sthafrca",
@@ -7506,7 +8169,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "cvni65pl",
@@ -7517,7 +8181,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "cvnid_amb",
@@ -7528,7 +8193,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "osthrnafr",
@@ -7539,7 +8205,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "se_g9t12",
@@ -7550,7 +8217,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "School Enrollment"
     },
     {
         "pff_variable": "frnotbsq",
@@ -7561,7 +8229,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "syrian",
@@ -7572,7 +8241,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "cvpop18pl",
@@ -7583,7 +8253,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Veteran Status"
     },
     {
         "pff_variable": "jamaican",
@@ -7594,7 +8265,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "c1864dild",
@@ -7605,7 +8277,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "fb3",
@@ -7616,7 +8289,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "U.S. Citizenship Status"
     },
     {
         "pff_variable": "se_clggsc",
@@ -7627,7 +8301,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "School Enrollment"
     },
     {
         "pff_variable": "wafr",
@@ -7638,7 +8313,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "cvnid",
@@ -7649,7 +8325,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "carprusn",
@@ -7660,7 +8337,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "caboverd",
@@ -7671,7 +8349,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "afg",
@@ -7682,7 +8361,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "ghana",
@@ -7693,7 +8373,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "cu18damb",
@@ -7704,7 +8385,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "hh1plu18",
@@ -7715,7 +8397,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "liberia",
@@ -7726,7 +8409,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "british",
@@ -7737,7 +8421,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "ms_mwd",
@@ -7748,7 +8433,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Marital Status"
     },
     {
         "pff_variable": "snglese",
@@ -7759,7 +8445,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "nigeria",
@@ -7770,7 +8457,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "russian",
@@ -7781,7 +8469,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "gprgcu18",
@@ -7792,7 +8481,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Grandparents"
     },
     {
         "pff_variable": "owafr",
@@ -7804,7 +8494,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "norwgian",
@@ -7815,7 +8506,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "sierral",
@@ -7826,7 +8518,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "afrnec",
@@ -7837,7 +8530,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "oceania",
@@ -7848,7 +8542,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "cvnid_scr",
@@ -7859,7 +8554,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "palstnian",
@@ -7870,7 +8566,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "ausnzsbr",
@@ -7881,7 +8578,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "c65pldamb",
@@ -7892,7 +8590,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "celtic",
@@ -7903,7 +8602,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "subsaf",
@@ -7914,7 +8614,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "scandnvn",
@@ -7925,7 +8626,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "ms_m15pl",
@@ -7936,7 +8638,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Marital Status"
     },
     {
         "pff_variable": "austrlia",
@@ -7947,7 +8650,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ms_mmrdsp",
@@ -7958,7 +8662,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Marital Status"
     },
     {
         "pff_variable": "othr",
@@ -7969,7 +8674,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "oausnzsbr",
@@ -7980,7 +8686,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "canadian",
@@ -7991,7 +8698,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "dhnonyc",
@@ -8002,7 +8710,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Residence 1 Year Ago"
     },
     {
         "pff_variable": "fiji",
@@ -8013,7 +8722,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "popinfms",
@@ -8026,7 +8736,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Social-Special Variable"
     },
     {
         "pff_variable": "ocnianec",
@@ -8038,7 +8749,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "amricas",
@@ -8049,7 +8761,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "lam",
@@ -8060,7 +8773,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "c65pldscr",
@@ -8071,7 +8785,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "carib",
@@ -8082,7 +8797,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "c65pldcog",
@@ -8093,7 +8809,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "bahamas",
@@ -8104,7 +8821,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "haitian",
@@ -8115,7 +8833,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "pop_5",
@@ -8126,7 +8845,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "c1864dcog",
@@ -8137,7 +8857,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "latvian",
@@ -8148,7 +8869,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "ukrnian",
@@ -8159,7 +8881,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "barbados",
@@ -8170,7 +8893,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ea_lt9g",
@@ -8181,7 +8905,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Educational Attainment (Highest Grade Completed)"
     },
     {
         "pff_variable": "nigerian",
@@ -8192,7 +8917,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "cuba",
@@ -8203,7 +8929,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "windnhsp",
@@ -8214,7 +8941,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "dominica",
@@ -8225,7 +8953,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "cu18dhrg",
@@ -8236,7 +8965,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "ntvprusab",
@@ -8247,7 +8977,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "fb1",
@@ -8258,7 +8989,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "domrep",
@@ -8269,7 +9001,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "grenada",
@@ -8280,7 +9013,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "danish",
@@ -8291,7 +9025,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "haiti",
@@ -8302,7 +9037,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "penngerm",
@@ -8313,7 +9049,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "jamaica",
@@ -8324,7 +9061,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "stvgren",
@@ -8335,7 +9073,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "scottish",
@@ -8346,7 +9085,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "icelndr",
@@ -8357,7 +9097,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "trandtob",
@@ -8368,7 +9109,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "swedish",
@@ -8379,7 +9121,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "cajun",
@@ -8390,7 +9133,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "fb2000ltr",
@@ -8402,7 +9146,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "fb2010ltr",
@@ -8413,7 +9158,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year of Entry"
     },
     {
         "pff_variable": "windies",
@@ -8424,7 +9170,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "pop3plen",
@@ -8435,7 +9182,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "School Enrollment"
     },
     {
         "pff_variable": "ocarib",
@@ -8446,7 +9194,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "cam",
@@ -8457,7 +9206,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "dutch",
@@ -8468,7 +9218,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "african",
@@ -8479,7 +9230,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "belize",
@@ -8490,7 +9242,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "slavic",
@@ -8501,7 +9254,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "owind",
@@ -8512,7 +9266,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "cstarica",
@@ -8523,7 +9278,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "hh3",
@@ -8534,7 +9290,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Computers and Internet Use"
     },
     {
         "pff_variable": "elslvdr",
@@ -8545,7 +9302,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "se_nscpsc",
@@ -8556,7 +9314,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "School Enrollment"
     },
     {
         "pff_variable": "bahamian",
@@ -8567,7 +9326,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "guatmala",
@@ -8578,7 +9338,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "fb4",
@@ -8589,7 +9350,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Year of Entry"
     },
     {
         "pff_variable": "hhint",
@@ -8600,7 +9362,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Computers and Internet Use"
     },
     {
         "pff_variable": "armenian",
@@ -8611,7 +9374,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "iranian",
@@ -8622,7 +9386,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "basque",
@@ -8633,7 +9398,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "welsh",
@@ -8644,7 +9410,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "honduras",
@@ -8655,7 +9422,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "nfama65pl",
@@ -8667,7 +9435,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "mexico",
@@ -8678,7 +9447,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "famchu18",
@@ -8691,7 +9461,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "nicargua",
@@ -8702,7 +9473,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "italian",
@@ -8713,7 +9485,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "panama",
@@ -8724,7 +9497,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ea_lthsgr",
@@ -8736,7 +9510,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Educational Attainment (Highest Grade Completed)"
     },
     {
         "pff_variable": "ocam",
@@ -8747,7 +9522,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "sam",
@@ -8758,7 +9534,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "cvnid_ild",
@@ -8769,7 +9546,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": "Disability Status of the Civilian Noninstitutionalized Population"
     },
     {
         "pff_variable": "argntina",
@@ -8780,7 +9558,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "hhpop1",
@@ -8791,7 +9570,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Social-Special Variable"
     },
     {
         "pff_variable": "rshphhldr",
@@ -8802,7 +9582,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Relationship to Head of Household (Householder)"
     },
     {
         "pff_variable": "lebanese",
@@ -8813,7 +9594,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "turkish",
@@ -8824,7 +9606,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "bolivia",
@@ -8835,7 +9618,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "estonian",
@@ -8846,7 +9630,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "brazil",
@@ -8857,7 +9642,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "rshp_othr",
@@ -8868,7 +9654,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Relationship to Head of Household (Householder)"
     },
     {
         "pff_variable": "chile",
@@ -8879,7 +9666,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "colombia",
@@ -8890,7 +9678,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "ms_mdvcd",
@@ -8901,7 +9690,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Marital Status"
     },
     {
         "pff_variable": "ms_fdvcd",
@@ -8912,7 +9702,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Marital Status"
     },
     {
         "pff_variable": "ecuador",
@@ -8923,7 +9714,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "guyana",
@@ -8934,7 +9726,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "peru",
@@ -8945,7 +9738,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "se_kndgtn",
@@ -8956,7 +9750,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "School Enrollment"
     },
     {
         "pff_variable": "fam3",
@@ -8967,7 +9762,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Social-Special Variable"
     },
     {
         "pff_variable": "uruguay",
@@ -8978,7 +9774,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "pop1pl",
@@ -8989,7 +9786,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Residence 1 Year Ago"
     },
     {
         "pff_variable": "hh4",
@@ -9000,7 +9798,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Social-Special Variable"
     },
     {
         "pff_variable": "vnzuela",
@@ -9011,7 +9810,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "safrican",
@@ -9022,7 +9822,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "hgrian",
@@ -9033,7 +9834,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "austrian",
@@ -9044,7 +9846,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "osam",
@@ -9055,7 +9858,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "nam",
@@ -9066,7 +9870,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "canada",
@@ -9077,7 +9882,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "slovene",
@@ -9088,7 +9894,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "onam",
@@ -9099,7 +9906,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "bermudan",
@@ -9110,7 +9918,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Ancestry"
     },
     {
         "pff_variable": "fb2",
@@ -9121,7 +9930,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Place of Birth"
     },
     {
         "pff_variable": "pop",
@@ -9132,7 +9942,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "pop25t29",
@@ -9144,7 +9955,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "pop40t44",
@@ -9156,7 +9968,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "fpop0t5",
@@ -9167,7 +9980,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "fem",
@@ -9178,7 +9992,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "asnvtn",
@@ -9189,7 +10004,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "mdpop50t54",
@@ -9201,7 +10017,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "hspsam",
@@ -9212,7 +10029,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "mpop35t39",
@@ -9223,7 +10041,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "hspspnsh",
@@ -9234,7 +10053,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "asnbhutn",
@@ -9245,7 +10065,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "pop85pl",
@@ -9256,7 +10077,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "pop55t59",
@@ -9267,7 +10089,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "mdpop35t39",
@@ -9279,7 +10102,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "mdpop67t69",
@@ -9291,7 +10115,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "mdpop18t19",
@@ -9303,7 +10128,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "asnkor",
@@ -9314,7 +10140,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "mpop5t9",
@@ -9325,7 +10152,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "asnhmng",
@@ -9336,7 +10164,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "mdpop20",
@@ -9348,7 +10177,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "asneast",
@@ -9364,7 +10194,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "pop_1",
@@ -9375,7 +10206,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "mpop15t19",
@@ -9387,7 +10219,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "pop65pl2",
@@ -9398,7 +10231,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "fpop80t84",
@@ -9409,7 +10243,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "pop20t24",
@@ -9420,7 +10255,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "pop70t74",
@@ -9432,7 +10268,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "fpop70t74",
@@ -9443,7 +10280,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "hsp2",
@@ -9454,7 +10292,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "mpop75t79",
@@ -9465,7 +10304,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "mdage",
@@ -9476,7 +10316,8 @@
         "domain": "social",
         "rounding": "1",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "mdpop65t66",
@@ -9488,7 +10329,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "pop65plf",
@@ -9499,7 +10341,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "popu5",
@@ -9510,7 +10353,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "nhsp",
@@ -9521,7 +10365,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Mutually Exclusive Race/Hispanic Origin"
     },
     {
         "pff_variable": "fpop20t24",
@@ -9534,7 +10379,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "asnoasn",
@@ -9546,7 +10392,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "hspperu",
@@ -9557,7 +10404,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "hsppr",
@@ -9568,7 +10416,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "mpop55t59",
@@ -9579,7 +10428,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "mdpop21",
@@ -9591,7 +10441,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "fpop60t64",
@@ -9603,7 +10454,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "asnind",
@@ -9614,7 +10466,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "hspcol",
@@ -9625,7 +10478,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "mpop85pl",
@@ -9636,7 +10490,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "mdpop30t34",
@@ -9648,7 +10503,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "asnsouth",
@@ -9664,7 +10520,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "mpop25t29",
@@ -9675,7 +10532,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "hspvnz",
@@ -9686,7 +10544,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "mdpop_3",
@@ -9697,7 +10556,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "popu18f",
@@ -9708,7 +10568,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "hspec",
@@ -9719,7 +10580,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "fpop25t29",
@@ -9730,7 +10592,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "asnmgol",
@@ -9741,7 +10604,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "mpop70t74",
@@ -9752,7 +10616,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "fpop35t39",
@@ -9763,7 +10628,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "fpop85pl",
@@ -9774,7 +10640,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "nhpinh",
@@ -9785,7 +10652,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Mutually Exclusive Race/Hispanic Origin"
     },
     {
         "pff_variable": "hsposam",
@@ -9796,7 +10664,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "mpop80t84",
@@ -9807,7 +10676,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "mdpop62t64",
@@ -9819,7 +10689,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "mpop0t5",
@@ -9830,7 +10701,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "asnsril",
@@ -9841,7 +10713,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "pop60t64",
@@ -9852,7 +10725,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "pop50t54",
@@ -9864,7 +10738,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "fpop55t59",
@@ -9875,7 +10750,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "pop80t84",
@@ -9887,7 +10763,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "hspdom",
@@ -9898,7 +10775,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "pop15t19",
@@ -9909,7 +10787,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "pop65pl1",
@@ -9920,7 +10799,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "mdpop85pl",
@@ -9932,7 +10812,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "hspurg",
@@ -9943,7 +10824,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "popu18m",
@@ -9954,7 +10836,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "pop35t39",
@@ -9966,7 +10849,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "pop75t79",
@@ -9978,7 +10862,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "asnnepal",
@@ -9989,7 +10874,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "hspchl",
@@ -10000,7 +10886,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "hspme",
@@ -10011,7 +10898,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "mpop20t24",
@@ -10024,7 +10912,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "asnseast",
@@ -10043,7 +10932,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "mdpop75t79",
@@ -10055,7 +10945,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "othnh",
@@ -10066,7 +10957,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Mutually Exclusive Race/Hispanic Origin"
     },
     {
         "pff_variable": "hspcr",
@@ -10077,7 +10969,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "asncmb",
@@ -10088,7 +10981,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "hspalloth",
@@ -10099,7 +10993,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "fpop40t44",
@@ -10110,7 +11005,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "hsppan",
@@ -10121,7 +11017,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "pop10t14",
@@ -10132,7 +11029,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "asnpak",
@@ -10143,7 +11041,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "fpop65t69",
@@ -10155,7 +11054,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "mdpop10t14",
@@ -10167,7 +11067,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "wtnh",
@@ -10178,7 +11079,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Mutually Exclusive Race/Hispanic Origin"
     },
     {
         "pff_variable": "asnburm",
@@ -10189,7 +11091,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "asnflp",
@@ -10200,7 +11103,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "mdpop70t74",
@@ -10212,7 +11116,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "mdpop40t44",
@@ -10224,7 +11129,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "hsp1",
@@ -10235,7 +11141,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Mutually Exclusive Race/Hispanic Origin"
     },
     {
         "pff_variable": "hsphnd",
@@ -10246,7 +11153,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "pop65t69",
@@ -10260,7 +11168,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "asnindnsn",
@@ -10271,7 +11180,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "fpop30t34",
@@ -10282,7 +11192,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "fpop75t79",
@@ -10293,7 +11204,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "popu18_2",
@@ -10304,7 +11216,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "mdpop80t84",
@@ -10316,7 +11229,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "fpop50t54",
@@ -10327,7 +11241,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "mdpop55t59",
@@ -10339,7 +11254,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "hspguatm",
@@ -10350,7 +11266,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "fpop45t49",
@@ -10361,7 +11278,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "hspcub",
@@ -10372,7 +11290,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "hspcam",
@@ -10383,7 +11302,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "hspspnrd",
@@ -10394,7 +11314,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "hspsalv",
@@ -10405,7 +11326,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "mpop50t54",
@@ -10416,7 +11338,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "asnjpn",
@@ -10427,7 +11350,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "asnthai",
@@ -10438,7 +11362,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "asn2pl",
@@ -10449,7 +11374,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "asntwn",
@@ -10460,7 +11386,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "asnbng",
@@ -10471,7 +11398,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "fpop15t19",
@@ -10483,7 +11411,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "hspspam",
@@ -10494,7 +11423,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "asnlao",
@@ -10505,7 +11435,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "aiannh",
@@ -10516,7 +11447,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Mutually Exclusive Race/Hispanic Origin"
     },
     {
         "pff_variable": "hspprg",
@@ -10527,7 +11459,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "mdpop0t4",
@@ -10539,7 +11472,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "popu181",
@@ -10550,7 +11484,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "hspocam",
@@ -10561,7 +11496,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "mpop10t14",
@@ -10572,7 +11508,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "mpop45t49",
@@ -10583,7 +11520,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "asnmalsn",
@@ -10594,7 +11532,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "pop_2",
@@ -10605,7 +11544,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Mutually Exclusive Race/Hispanic Origin"
     },
     {
         "pff_variable": "mpop30t34",
@@ -10616,7 +11556,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "mpop60t64",
@@ -10628,7 +11569,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "pop30t34",
@@ -10640,7 +11582,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "mdpop5t9",
@@ -10652,7 +11595,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "mdpop60t61",
@@ -10664,7 +11608,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "asnchinot",
@@ -10675,7 +11620,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "mpop40t44",
@@ -10686,7 +11632,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "mdpop22t24",
@@ -10698,7 +11645,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "blnh",
@@ -10709,7 +11657,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Mutually Exclusive Race/Hispanic Origin"
     },
     {
         "pff_variable": "asnnh",
@@ -10720,7 +11669,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Mutually Exclusive Race/Hispanic Origin"
     },
     {
         "pff_variable": "mdpop15t17",
@@ -10732,7 +11682,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "hspbol",
@@ -10743,7 +11694,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "rc2plnh",
@@ -10754,7 +11706,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Mutually Exclusive Race/Hispanic Origin"
     },
     {
         "pff_variable": "pop45t49",
@@ -10766,7 +11719,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "pop65plm",
@@ -10777,7 +11731,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "pop5t9",
@@ -10788,7 +11743,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "hspnic",
@@ -10799,7 +11755,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "hsparg",
@@ -10810,7 +11767,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "hspoth",
@@ -10821,7 +11779,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Hispanic Subgroup"
     },
     {
         "pff_variable": "male",
@@ -10832,7 +11791,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Sex and Age"
     },
     {
         "pff_variable": "fpop10t14",
@@ -10843,7 +11803,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "mpop65t69",
@@ -10855,7 +11816,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "mdpop25t29",
@@ -10867,7 +11829,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "mdpop45t49",
@@ -10879,7 +11842,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Demographic- Special Variable"
     },
     {
         "pff_variable": "fpop5t9",
@@ -10890,7 +11854,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "PopPyramid Only"
     },
     {
         "pff_variable": "asnokinw",
@@ -10901,7 +11866,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "asn1rc",
@@ -10912,7 +11878,8 @@
         "domain": "demographic",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Asian Subgroup"
     },
     {
         "pff_variable": "c1864dambp",
@@ -10923,7 +11890,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "c1864dcogp",
@@ -10934,7 +11902,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "c1864dhrgp",
@@ -10945,7 +11914,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "c1864dildp",
@@ -10956,7 +11926,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "c1864dscrp",
@@ -10967,7 +11938,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "c1864dvsnp",
@@ -10978,7 +11950,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "c65pldambp",
@@ -10989,7 +11962,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "c65pldcogp",
@@ -11000,7 +11974,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "c65pldhrgp",
@@ -11011,7 +11986,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "c65pldildp",
@@ -11022,7 +11998,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "c65pldscrp",
@@ -11033,7 +12010,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "c65pldvsnp",
@@ -11044,7 +12022,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "cu18dambp",
@@ -11055,7 +12034,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "cu18dcogp",
@@ -11066,7 +12046,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "cu18dhrgp",
@@ -11077,7 +12058,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "cu18dscrp",
@@ -11088,7 +12070,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "cu18dvsnp",
@@ -11099,7 +12082,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "cvnid_ambp",
@@ -11110,7 +12094,8 @@
         "domain": "Social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "cvnid_cogp",
@@ -11121,7 +12106,8 @@
         "domain": "Social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "cvnid_hrgp",
@@ -11132,7 +12118,8 @@
         "domain": "Social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "cvnid_ildp",
@@ -11143,7 +12130,8 @@
         "domain": "Social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "cvnid_scrp",
@@ -11154,7 +12142,8 @@
         "domain": "Social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "cvnid_vsnp",
@@ -11165,7 +12154,8 @@
         "domain": "Social",
         "rounding": "0",
         "source": "subject",
-        "Notes": ""
+        "Notes": "",
+        "category": ""
     },
     {
         "pff_variable": "engonly1",
@@ -11176,7 +12166,8 @@
         "domain": "Social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "engonly2",
@@ -11187,7 +12178,8 @@
         "domain": "Social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "fhns",
@@ -11198,7 +12190,8 @@
         "domain": "Social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "fhnschu18",
@@ -11209,7 +12202,8 @@
         "domain": "Social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "lgarab1",
@@ -11220,7 +12214,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgarab2",
@@ -11231,7 +12226,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgarblep1",
@@ -11242,7 +12238,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgarblep2",
@@ -11253,7 +12250,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgchi1",
@@ -11264,7 +12262,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgchi2",
@@ -11275,7 +12274,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgchilep1",
@@ -11286,7 +12286,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgchilep2",
@@ -11297,7 +12298,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgfr1",
@@ -11308,7 +12310,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgfr2",
@@ -11319,7 +12322,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgfrlep1",
@@ -11330,7 +12334,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgfrlep2",
@@ -11341,7 +12346,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lggrm1",
@@ -11352,7 +12358,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lggrm2",
@@ -11363,7 +12370,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lggrmlep1",
@@ -11374,7 +12382,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lggrmlep2",
@@ -11385,7 +12394,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgkor1",
@@ -11396,7 +12406,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgkor2",
@@ -11407,7 +12418,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgkorlep1",
@@ -11418,7 +12430,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgkorlep2",
@@ -11429,7 +12442,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgoanlep1",
@@ -11440,7 +12454,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgoanlep2",
@@ -11451,7 +12466,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgoasn1",
@@ -11462,7 +12478,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgoasn2",
@@ -11473,7 +12490,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgoeng1",
@@ -11495,7 +12513,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgoeng2",
@@ -11517,7 +12536,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgoenlep2",
@@ -11539,7 +12559,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgoielep1",
@@ -11550,7 +12571,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgoielep2",
@@ -11561,7 +12583,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgoieu1",
@@ -11572,7 +12595,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgoieu2",
@@ -11583,7 +12607,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgolg1",
@@ -11594,7 +12619,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgolg2",
@@ -11605,7 +12631,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgolglep1",
@@ -11616,7 +12643,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgolglep2",
@@ -11627,7 +12655,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgrsplep1",
@@ -11638,7 +12667,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgrsplep2",
@@ -11649,7 +12679,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgruspol1",
@@ -11660,7 +12691,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgruspol2",
@@ -11671,7 +12703,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgsp1",
@@ -11682,7 +12715,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgsp2",
@@ -11693,7 +12727,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgsplep1",
@@ -11704,7 +12739,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgsplep2",
@@ -11715,7 +12751,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgtag1",
@@ -11726,7 +12763,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgtag2",
@@ -11737,7 +12775,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgtaglep1",
@@ -11748,7 +12787,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgtaglep2",
@@ -11759,7 +12799,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgvielep1",
@@ -11770,7 +12811,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgvielep2",
@@ -11781,7 +12823,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgviet1",
@@ -11792,7 +12835,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "lgviet2",
@@ -11803,7 +12847,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "mhns",
@@ -11814,7 +12859,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "mhnschu18",
@@ -11825,7 +12871,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Household Type"
     },
     {
         "pff_variable": "pop5pl1",
@@ -11836,7 +12883,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "pop5pl2",
@@ -11847,7 +12895,8 @@
         "domain": "social",
         "rounding": "0",
         "source": "",
-        "Notes": ""
+        "Notes": "",
+        "category": "Language Spoken at Home"
     },
     {
         "pff_variable": "grpi30pl",
@@ -11859,6 +12908,7 @@
         "domain": "housing",
         "rounding": "0",
         "source": "profile",
-        "Notes": ""
+        "Notes": "",
+        "category": "Gross Rent as a Percentage of Household Income (GRAPI)"
     }
 ]

--- a/pipelines/convert_metadata.js
+++ b/pipelines/convert_metadata.js
@@ -1,0 +1,53 @@
+// Script to be run in Excel to convert a metadata table to JSON
+function main(workbook: ExcelScript.Workbook): TableData[] {
+    // Get the first table in the "meta2017-2021" worksheet.
+    // If you know the table name, use `workbook.getTable('TableName')` instead.
+    const table = workbook.getWorksheet('meta2017-2021').getTables()[0];
+
+    // Get all the values from the table as text.
+    const texts = table.getRange().getTexts();
+
+    // Create an array of JSON objects that match the row structure.
+    let returnObjects: TableData[] = [];
+    if (table.getRowCount() > 0) {
+        returnObjects = returnObjectFromValues(texts);
+    }
+
+    // Log the information and return it for a Power Automate flow.
+    console.log(JSON.stringify(returnObjects));
+    return returnObjects
+}
+
+// This function converts a 2D array of values into a generic JSON object.
+// In this case, we have defined the TableData object, but any similar interface would work.
+function returnObjectFromValues(values: string[][]): TableData[] {
+    let objectArray: TableData[] = [];
+    let objectKeys: string[] = [];
+    for (let i = 0; i < values.length; i++) {
+        if (i === 0) {
+            objectKeys = values[i]
+            continue;
+        }
+
+        let object: { [key: string]: string } = {}
+        for (let j = 0; j < values[i].length; j++) {
+            object[objectKeys[j]] = values[i][j]
+        }
+
+        objectArray.push(object as unknown as TableData);
+    }
+
+    return objectArray;
+}
+
+interface TableData {
+    "Event ID": string
+    pff_variable: string
+    base_variable: string
+    census_variable: string
+    domain: string
+    rounding: number
+    category: string
+    source: string
+    Notes: string
+}


### PR DESCRIPTION
closes #254 

## motivations
- `metadata.json` was missing the category field
- JSON file was generated by converting the provided Excel file using a script in Excel

## changes
- add `metadata.json` which was generated with a new source excel file
- add javascript code used in Excel Code Editor

## tests
- ran [Build - ACS Manual Update action](https://github.com/NYCPlanning/db-factfinder/actions/runs/4536239403/jobs/7992683610#step:7:16) to push to S3 with `year=2021` and `geography=2010_to_2020`