### PR TITLE
Fix 2021 ACS Metdata

### DIFF
--- a/factfinder/data/acs/2021/metadata.json
+++ b/factfinder/data/acs/2021/metadata.json
@@ -12159,7 +12159,7 @@
     },
     {
         "pff_variable": "engonly1",
-        "base_variable": "Pop5pl1",
+        "base_variable": "pop5pl1",
         "census_variable": [
             "C16001_002"
         ],
@@ -12171,7 +12171,7 @@
     },
     {
         "pff_variable": "engonly2",
-        "base_variable": "Pop5pl2",
+        "base_variable": "pop5pl2",
         "census_variable": [
             "C16001_002"
         ],
@@ -12495,7 +12495,7 @@
     },
     {
         "pff_variable": "lgoeng1",
-        "base_variable": "Pop5pl1",
+        "base_variable": "pop5pl1",
         "census_variable": [
             "C16001_003",
             "C16001_006",

--- a/factfinder/data/acs/2021/metadata.json
+++ b/factfinder/data/acs/2021/metadata.json
@@ -12091,7 +12091,7 @@
         "census_variable": [
             "S1810_C03_047"
         ],
-        "domain": "Social",
+        "domain": "social",
         "rounding": "0",
         "source": "subject",
         "Notes": "",
@@ -12103,7 +12103,7 @@
         "census_variable": [
             "S1810_C03_039"
         ],
-        "domain": "Social",
+        "domain": "social",
         "rounding": "0",
         "source": "subject",
         "Notes": "",
@@ -12115,7 +12115,7 @@
         "census_variable": [
             "S1810_C03_019"
         ],
-        "domain": "Social",
+        "domain": "social",
         "rounding": "0",
         "source": "subject",
         "Notes": "",
@@ -12127,7 +12127,7 @@
         "census_variable": [
             "S1810_C03_063"
         ],
-        "domain": "Social",
+        "domain": "social",
         "rounding": "0",
         "source": "subject",
         "Notes": "",
@@ -12139,7 +12139,7 @@
         "census_variable": [
             "S1810_C03_055"
         ],
-        "domain": "Social",
+        "domain": "social",
         "rounding": "0",
         "source": "subject",
         "Notes": "",
@@ -12151,7 +12151,7 @@
         "census_variable": [
             "S1810_C03_029"
         ],
-        "domain": "Social",
+        "domain": "social",
         "rounding": "0",
         "source": "subject",
         "Notes": "",
@@ -12159,11 +12159,11 @@
     },
     {
         "pff_variable": "engonly1",
-        "base_variable": "pop5pl1",
+        "base_variable": "Pop5pl1",
         "census_variable": [
             "C16001_002"
         ],
-        "domain": "Social",
+        "domain": "social",
         "rounding": "0",
         "source": "",
         "Notes": "",
@@ -12171,11 +12171,11 @@
     },
     {
         "pff_variable": "engonly2",
-        "base_variable": "pop5pl2",
+        "base_variable": "Pop5pl2",
         "census_variable": [
             "C16001_002"
         ],
-        "domain": "Social",
+        "domain": "social",
         "rounding": "0",
         "source": "",
         "Notes": "",
@@ -12187,7 +12187,7 @@
         "census_variable": [
             "B11003_015"
         ],
-        "domain": "Social",
+        "domain": "social",
         "rounding": "0",
         "source": "",
         "Notes": "",
@@ -12199,7 +12199,7 @@
         "census_variable": [
             "B11003_016"
         ],
-        "domain": "Social",
+        "domain": "social",
         "rounding": "0",
         "source": "",
         "Notes": "",
@@ -12495,7 +12495,7 @@
     },
     {
         "pff_variable": "lgoeng1",
-        "base_variable": "pop5pl1",
+        "base_variable": "Pop5pl1",
         "census_variable": [
             "C16001_003",
             "C16001_006",


### PR DESCRIPTION
This PR updates the `domain` value for some 2021 ACS metadata so that `social` is consistently all lowercase. This is required for [part of](https://github.com/NYCPlanning/labs-factfinder-api/blob/develop/migrations/acs_metadata.sql#L29) OSE's data scripts to work correctly.